### PR TITLE
fix: only block actual IPv6 ULA literals in SSRF guard

### DIFF
--- a/app/api/fetch-url/route.ts
+++ b/app/api/fetch-url/route.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net"
 import { NextRequest, NextResponse } from "next/server"
 
 type UrlMeta = {
@@ -90,9 +91,10 @@ function isBlockedHost(rawUrl: string): boolean {
   if (h === "localhost") return true
   if (h === "metadata.google.internal") return true
 
-  // IPv6 loopback and link-local
+  // IPv6 loopback, link-local, and ULA. Only apply these checks to real IPv6
+  // literals, not normal hostnames that merely begin with "fc" or "fd".
   if (h === "::1" || h === "0:0:0:0:0:0:0:1") return true
-  if (h.startsWith("fe80:") || h.startsWith("fc") || h.startsWith("fd")) return true
+  if (isIP(h) === 6 && (h.startsWith("fe80:") || h.startsWith("fc") || h.startsWith("fd"))) return true
 
   // IPv4 private / reserved ranges
   const ipv4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)


### PR DESCRIPTION
## Summary
- use 
ode:net IP detection before applying IPv6 ULA checks
- keep blocking loopback, link-local, and ULA IPv6 literals
- stop falsely blocking ordinary hostnames that merely start with c or d

## Why
The current SSRF guard treats any hostname beginning with c or d as an IPv6 ULA address. That incorrectly blocks legitimate hostnames even when they are not IP literals.

This change restricts ULA checks to actual IPv6 literal hosts only.

## Validation
- 
pm run build
- matches issue #14 repro/intent
