### PR TITLE
Add Fireworks provider and Exa-based unified web grounding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 .claude/
 tsconfig.tsbuildinfo
 next-env.d.ts
+pnpm-lock.yaml
 
 # Internal docs
 CLAUDE.md

--- a/components/project-sidebar.tsx
+++ b/components/project-sidebar.tsx
@@ -71,6 +71,7 @@ export function ProjectSidebar({
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [showSettings, setShowSettings] = useState(false)
   const [showKey, setShowKey] = useState(false)
+  const [showExaKey, setShowExaKey] = useState(false)
   const [modelOpen, setModelOpen] = useState(false)
   const [providerOpen, setProviderOpen] = useState(false)
   // local draft for settings (only save on "Save")
@@ -110,11 +111,12 @@ export function ProjectSidebar({
   const persistSettings = () => {
     // Trim key to strip accidental whitespace/newlines from paste
     const trimmedKey = draft.apiKey.trim()
+    const trimmedExaKey = (draft.exaApiKey ?? "").trim()
     const providerKeys: Partial<Record<AIProvider, string>> = {
       ...(draft.providerKeys ?? {}),
       [draft.provider]: trimmedKey,
     }
-    onUpdateAISettings({ ...draft, apiKey: trimmedKey, providerKeys })
+    onUpdateAISettings({ ...draft, apiKey: trimmedKey, exaApiKey: trimmedExaKey, providerKeys })
   }
 
   const handleSaveSettings = () => {
@@ -447,35 +449,80 @@ export function ProjectSidebar({
                   )}
                 </div>
 
-                {/* Web Grounding (OpenRouter + OpenAI) */}
-                {(draft.provider === "openrouter" || draft.provider === "openai") && selectedModel && (
-                  <div className="flex items-start justify-between gap-3 rounded-md border border-white/5 bg-white/[0.02] px-2.5 py-2.5">
-                    <div className="flex items-start gap-2">
-                      <Globe className="h-3.5 w-3.5 mt-0.5 text-primary/60 shrink-0" />
-                      <div>
-                        <div className="font-mono text-[11px] font-bold text-foreground">Web Grounding</div>
-                        <div className="font-mono text-[9px] text-muted-foreground mt-0.5 leading-relaxed">
-                          {selectedModel.supportsGrounding
-                            ? draft.provider === "openai"
-                              ? `Uses ${selectedModel.groundingModelId ?? "search-preview"} for live web access`
-                              : "Adds :online for live search"
-                            : "Not available for this model"}
+                {/* Web Grounding — works for any provider when an Exa key is set,
+                    falls back to OpenRouter/OpenAI native search variants otherwise. */}
+                {(() => {
+                  const exaConfigured = (draft.exaApiKey ?? "").trim().length > 0
+                  const nativeAvailable =
+                    (draft.provider === "openrouter" || draft.provider === "openai") &&
+                    (selectedModel?.supportsGrounding ?? false)
+                  const groundingAvailable = exaConfigured || nativeAvailable
+                  const effectivelyOn = draft.webGrounding && groundingAvailable
+                  const description = exaConfigured
+                    ? "Live web search via Exa — works on any provider"
+                    : nativeAvailable
+                      ? draft.provider === "openai"
+                        ? `Uses ${selectedModel?.groundingModelId ?? "search-preview"} for live web access`
+                        : "Adds :online for live search"
+                      : "Add an Exa key below to enable grounding for this provider"
+
+                  if (!selectedModel) return null
+
+                  return (
+                    <div className="flex items-start justify-between gap-3 rounded-md border border-white/5 bg-white/[0.02] px-2.5 py-2.5">
+                      <div className="flex items-start gap-2">
+                        <Globe className="h-3.5 w-3.5 mt-0.5 text-primary/60 shrink-0" />
+                        <div>
+                          <div className="font-mono text-[11px] font-bold text-foreground">Web Grounding</div>
+                          <div className="font-mono text-[9px] text-muted-foreground mt-0.5 leading-relaxed">
+                            {description}
+                          </div>
                         </div>
                       </div>
+                      <button
+                        onClick={() => groundingAvailable && setDraft(d => ({ ...d, webGrounding: !d.webGrounding }))}
+                        disabled={!groundingAvailable}
+                        className={`relative shrink-0 h-5 w-9 rounded-full transition-all duration-200 ${
+                          effectivelyOn ? "bg-primary" : "bg-white/10"
+                        } disabled:opacity-30 disabled:cursor-not-allowed`}
+                      >
+                        <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all duration-200 ${
+                          effectivelyOn ? "left-5" : "left-0.5"
+                        }`} />
+                      </button>
                     </div>
-                    <button
-                      onClick={() => selectedModel.supportsGrounding && setDraft(d => ({ ...d, webGrounding: !d.webGrounding }))}
-                      disabled={!selectedModel.supportsGrounding}
-                      className={`relative shrink-0 h-5 w-9 rounded-full transition-all duration-200 ${
-                        draft.webGrounding && selectedModel.supportsGrounding ? "bg-primary" : "bg-white/10"
-                      } disabled:opacity-30 disabled:cursor-not-allowed`}
-                    >
-                      <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all duration-200 ${
-                        draft.webGrounding && selectedModel.supportsGrounding ? "left-5" : "left-0.5"
-                      }`} />
+                  )
+                })()}
+
+                {/* Exa Search Key — optional, unlocks grounding for any provider */}
+                <div className="flex flex-col gap-2">
+                  <label className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+                    Exa Key · Web Search (optional)
+                  </label>
+                  <div className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-2 focus-within:border-primary/50 transition-colors">
+                    <Globe className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    <input
+                      type="text"
+                      value={draft.exaApiKey ?? ""}
+                      onChange={e => setDraft(d => ({ ...d, exaApiKey: e.target.value }))}
+                      placeholder="Your Exa API key"
+                      className="flex-1 bg-transparent font-mono text-[11px] text-foreground outline-none placeholder:text-muted-foreground/40"
+                      style={showExaKey ? undefined : { WebkitTextSecurity: "disc" } as never}
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                    <button onClick={() => setShowExaKey(v => !v)} className="text-muted-foreground hover:text-foreground transition-colors">
+                      {showExaKey ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
                     </button>
                   </div>
-                )}
+                  <p className="font-mono text-[9px] text-muted-foreground leading-relaxed">
+                    Enables web grounding for every provider via Exa search. Stored locally.{" "}
+                    <a href="https://dashboard.exa.ai/api-keys" target="_blank" rel="noopener noreferrer"
+                      className="text-primary underline hover:brightness-125 transition-all">
+                      Get a key →
+                    </a>
+                  </p>
+                </div>
 
                 {/* API Status */}
                 <div className={`flex items-center gap-2 rounded-md px-2.5 py-2 font-mono text-[9px] ${

--- a/lib/ai-enrich.ts
+++ b/lib/ai-enrich.ts
@@ -2,6 +2,7 @@
 
 import { detectContentType } from "@/lib/detect-content-type"
 import { loadAIConfig, getBaseUrl, getProviderHeaders, getModelsForProvider } from "@/lib/ai-settings"
+import { exaSearch, formatExaResultsForPrompt, type WebSearchResult } from "@/lib/web-search"
 import type { ContentType } from "@/lib/content-types"
 
 // ── Provider error parser ─────────────────────────────────────────────────────
@@ -265,17 +266,31 @@ export async function enrichBlockClient(
 
   const detectedType = detectContentType(text)
   const effectiveType = forcedType || detectedType
-  const shouldGround = config.supportsGrounding && TRUTH_DEPENDENT_TYPES.has(effectiveType)
+  const wantsGround = config.groundingMode !== "off" && TRUTH_DEPENDENT_TYPES.has(effectiveType)
 
   let model = config.modelId
   let webSearchOptions: Record<string, unknown> | undefined
-  if (shouldGround) {
-    if (config.provider === "openrouter") {
-      if (!model.endsWith(":online")) model = `${model}:online`
-    } else if (config.provider === "openai") {
-      const modelDef = getModelsForProvider("openai").find(m => m.id === config.modelId)
-      if (modelDef?.groundingModelId) model = modelDef.groundingModelId
-      webSearchOptions = {}
+  let exaContext = ""
+  let exaResults: WebSearchResult[] = []
+
+  if (wantsGround) {
+    if (config.groundingMode === "exa") {
+      // Search Exa with a trimmed version of the note so the query stays focused.
+      // Failure here should NOT block enrichment — fall through ungrounded.
+      try {
+        exaResults = await exaSearch(text.trim().slice(0, 500), config.exaApiKey, 5)
+        exaContext = formatExaResultsForPrompt(exaResults)
+      } catch (err) {
+        console.warn("[ai-enrich] Exa search failed, continuing without grounding:", err)
+      }
+    } else if (config.groundingMode === "native") {
+      if (config.provider === "openrouter") {
+        if (!model.endsWith(":online")) model = `${model}:online`
+      } else if (config.provider === "openai") {
+        const modelDef = getModelsForProvider("openai").find(m => m.id === config.modelId)
+        if (modelDef?.groundingModelId) model = modelDef.groundingModelId
+        webSearchOptions = {}
+      }
     }
   }
 
@@ -284,7 +299,10 @@ export async function enrichBlockClient(
   // fall back to json_object mode (guaranteed valid JSON, no schema enforcement)
   const useStrictSchema = supportsJsonSchema && !webSearchOptions
 
-  const groundingNote = shouldGround
+  // Native grounding tells the model "you have live web access" generically.
+  // Exa grounding injects actual results via exaContext, which already includes
+  // its own citation instructions, so we skip the generic note in that case.
+  const groundingNote = wantsGround && config.groundingMode === "native"
     ? `\n\n## Source Citations (grounded search active)
 You have live web access. For this note type, include 1–2 real source citations by name, publication, and year. Do NOT generate URLs — reference by title and author only (e.g. "Per *Science*, 2023, Doe et al."). Only cite sources you have actually retrieved.`
     : ""
@@ -297,7 +315,7 @@ You have live web access. For this note type, include 1–2 real source citation
     ? `\n\n## Output Format — CRITICAL\nYou MUST respond with a single JSON object (no markdown, no explanation). Schema:\n${JSON.stringify(JSON_SCHEMA.schema, null, 2)}`
     : ""
 
-  const systemPrompt = SYSTEM_PROMPT + groundingNote + schemaHint
+  const systemPrompt = SYSTEM_PROMPT + groundingNote + exaContext + schemaHint
 
   const categoryContext = category
     ? `\n\nThe user has assigned this note the category "${category}".`
@@ -418,7 +436,17 @@ You have live web access. For this note type, include 1–2 real source citation
       return true
     })
 
-  if (sources.length > 0) result.sources = sources
+  if (sources.length > 0) {
+    result.sources = sources
+  } else if (exaResults.length > 0) {
+    // Exa grounding path: results are not on `message.annotations`; build the
+    // tile-card source list from the search response we already have.
+    result.sources = exaResults.map(r => {
+      let siteName = ""
+      try { siteName = new URL(r.url).hostname.replace(/^www\./, "") } catch { /* ignore */ }
+      return { url: r.url, title: r.title || siteName, siteName }
+    })
+  }
 
   return result
 }

--- a/lib/ai-settings.ts
+++ b/lib/ai-settings.ts
@@ -12,7 +12,7 @@ export interface AIModel {
   groundingModelId?: string
 }
 
-export type AIProvider = "openrouter" | "openai" | "zai"
+export type AIProvider = "openrouter" | "openai" | "zai" | "fireworks"
 
 export interface AIProviderPreset {
   id: AIProvider
@@ -43,6 +43,13 @@ export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
     baseUrl: "https://api.z.ai/api/paas/v4",
     keyUrl: "https://z.ai/manage-apikey/apikey-list",
     keyPlaceholder: "Your Z.ai API key",
+  },
+  {
+    id: "fireworks",
+    label: "Fireworks (Fire Pass)",
+    baseUrl: "https://api.fireworks.ai/inference/v1",
+    keyUrl: "https://fireworks.ai/account/api-keys",
+    keyPlaceholder: "fw-...",
   },
 ]
 
@@ -174,9 +181,20 @@ export const ZAI_MODELS: AIModel[] = [
   },
 ]
 
+export const FIREWORKS_MODELS: AIModel[] = [
+  {
+    id: "accounts/fireworks/routers/kimi-k2p5-turbo",
+    label: "Kimi K2.5 Turbo",
+    shortLabel: "Kimi K2.5",
+    description: "Fire Pass · 262K context · tools + vision",
+    supportsGrounding: false,
+  },
+]
+
 export function getModelsForProvider(provider: AIProvider): AIModel[] {
-  if (provider === "openai") return OPENAI_MODELS
-  if (provider === "zai")    return ZAI_MODELS
+  if (provider === "openai")    return OPENAI_MODELS
+  if (provider === "zai")       return ZAI_MODELS
+  if (provider === "fireworks") return FIREWORKS_MODELS
   return AI_MODELS // openrouter + safe fallback for any stale localStorage value
 }
 
@@ -191,29 +209,40 @@ export interface AISettings {
   customBaseUrl: string
   /** Per-provider key store so switching back to a provider restores its key */
   providerKeys?: Partial<Record<AIProvider, string>>
+  /** Optional Exa API key. When set, web grounding works for ANY provider/model
+   *  via Exa search results injected into the system prompt — bypassing the
+   *  provider-specific search variants used by OpenAI/OpenRouter. */
+  exaApiKey: string
 }
+
+/** Which web-grounding strategy applies for this request:
+ *  - off:    no grounding
+ *  - native: provider has a hosted search variant (OpenAI search-preview, OpenRouter `:online`)
+ *  - exa:    user has an Exa key — works for every provider */
+export type GroundingMode = "off" | "native" | "exa"
 
 const STORAGE_KEY = "nodepad-ai-settings"
 
 function loadSettings(): AISettings {
   if (typeof window === "undefined") {
-    return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "" }
+    return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "", exaApiKey: "" }
   }
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "" }
+    if (!raw) return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "", exaApiKey: "" }
     return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "", ...JSON.parse(raw) }
   } catch {
-    return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "" }
+    return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "", exaApiKey: "" }
   }
 }
 
 export interface AIConfig {
   apiKey: string
   modelId: string
-  supportsGrounding: boolean
+  groundingMode: GroundingMode
   provider: AIProvider
   customBaseUrl: string
+  exaApiKey: string
 }
 
 export function loadAIConfig(): AIConfig | null {
@@ -226,12 +255,34 @@ export function loadAIConfig(): AIConfig | null {
   // OpenRouter-prefixed id (e.g. "openai/gpt-4o") after switching to OpenAI —
   // that string won't match any entry in OPENAI_MODELS so we fall back to "gpt-4o".
   const modelId = model?.id ?? models[0]?.id ?? s.modelId ?? DEFAULT_MODEL_ID
-  // Z.ai does not support grounding; only openrouter and openai do
-  const supportsGrounding =
-    (s.provider === "openrouter" || s.provider === "openai") &&
-    s.webGrounding &&
-    (model?.supportsGrounding ?? false)
-  return { apiKey: s.apiKey, modelId, supportsGrounding, provider: s.provider, customBaseUrl: s.customBaseUrl }
+  const exaApiKey = (s.exaApiKey ?? "").trim()
+
+  // Grounding mode resolution:
+  //  1. If toggle is off → "off".
+  //  2. If user has an Exa key → "exa" (works for every provider/model).
+  //  3. Otherwise fall back to the provider's native search variant when available
+  //     (OpenAI search-preview models, OpenRouter `:online`).
+  //  4. Else "off" — toggle is on but nothing can fulfil it (UI surfaces this).
+  let groundingMode: GroundingMode = "off"
+  if (s.webGrounding) {
+    if (exaApiKey) {
+      groundingMode = "exa"
+    } else if (
+      (s.provider === "openrouter" || s.provider === "openai") &&
+      (model?.supportsGrounding ?? false)
+    ) {
+      groundingMode = "native"
+    }
+  }
+
+  return {
+    apiKey: s.apiKey,
+    modelId,
+    groundingMode,
+    provider: s.provider,
+    customBaseUrl: s.customBaseUrl,
+    exaApiKey,
+  }
 }
 
 export function getBaseUrl(config: AIConfig): string {
@@ -271,7 +322,7 @@ export function useAISettings() {
   // modelLabel prop, etc.) between the server render and client hydration.
   const [settings, setSettings] = useState<AISettings>({
     apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false,
-    provider: DEFAULT_PROVIDER, customBaseUrl: "",
+    provider: DEFAULT_PROVIDER, customBaseUrl: "", exaApiKey: "",
   })
   const [isHydrated, setIsHydrated] = useState(false)
 
@@ -293,7 +344,15 @@ export function useAISettings() {
   const resolvedModelId = (() => {
     const model = models.find(m => m.id === settings.modelId) || models[0]
     if (!model) return settings.modelId
-    if (settings.provider === "openrouter" && settings.webGrounding && model.supportsGrounding) {
+    // Only append `:online` for OpenRouter's native grounding path. When an Exa
+    // key is present we ground through Exa instead and the base model id stays.
+    const exaConfigured = (settings.exaApiKey ?? "").trim().length > 0
+    if (
+      settings.provider === "openrouter" &&
+      settings.webGrounding &&
+      model.supportsGrounding &&
+      !exaConfigured
+    ) {
       return `${model.id}:online`
     }
     return model.id

--- a/lib/web-search.ts
+++ b/lib/web-search.ts
@@ -1,0 +1,72 @@
+// Lightweight Exa search adapter for unified web grounding across any AI provider.
+// Called directly from the browser — Exa allows CORS and the API key stays in
+// localStorage like every other key in the app.
+
+export interface WebSearchResult {
+  title: string
+  url: string
+  snippet: string
+  publishedDate?: string
+}
+
+export async function exaSearch(
+  query: string,
+  apiKey: string,
+  numResults = 5,
+): Promise<WebSearchResult[]> {
+  const trimmedQuery = query.trim()
+  if (!trimmedQuery || !apiKey) return []
+
+  const res = await fetch("https://api.exa.ai/search", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: trimmedQuery,
+      type: "auto",
+      num_results: numResults,
+      contents: { highlights: { max_characters: 1200 } },
+    }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`Exa search failed (${res.status}): ${body || res.statusText}`)
+  }
+
+  const data = (await res.json().catch(() => null)) as { results?: unknown } | null
+  const raw = Array.isArray(data?.results) ? (data!.results as unknown[]) : []
+
+  return raw
+    .map((r) => {
+      const o = r as Record<string, unknown>
+      const highlights = Array.isArray(o.highlights)
+        ? (o.highlights as unknown[]).map(String)
+        : []
+      return {
+        title: String(o.title ?? ""),
+        url: String(o.url ?? ""),
+        snippet: highlights.join(" … ").trim(),
+        publishedDate: typeof o.publishedDate === "string" ? o.publishedDate : undefined,
+      }
+    })
+    .filter((r) => r.url)
+}
+
+export function formatExaResultsForPrompt(results: WebSearchResult[]): string {
+  if (results.length === 0) return ""
+  const block = results
+    .map((r, i) => {
+      const date = r.publishedDate ? ` (${r.publishedDate.slice(0, 10)})` : ""
+      return `[${i + 1}] ${r.title}${date}\n${r.url}\n${r.snippet}`
+    })
+    .join("\n\n")
+  return `\n\n## Live Web Search Results
+The following sources were retrieved live for this query via web search. Treat them as the primary evidence for any factual claims in your annotation. Cite sources by name only (e.g. "Per LitCharts" or "Per the Studypool summary"). Never generate or guess URLs — the user sees the source list separately as clickable links.
+
+<search_results>
+${block}
+</search_results>`
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -47,7 +47,7 @@ const nextConfig = {
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cloud.umami.is",
               "style-src 'self' 'unsafe-inline'",
-              "connect-src 'self' https://openrouter.ai https://api.openai.com https://api.z.ai https://cloud.umami.is https://api-gateway.umami.dev",
+              "connect-src 'self' https://openrouter.ai https://api.openai.com https://api.z.ai https://api.fireworks.ai https://api.exa.ai https://cloud.umami.is https://api-gateway.umami.dev",
               "img-src 'self' data: blob: https://i.ytimg.com",
               "font-src 'self' data:",
               "frame-src https://www.youtube-nocookie.com https://www.youtube.com",


### PR DESCRIPTION
## Summary

- **New provider: Fireworks (Fire Pass)** — adds `accounts/fireworks/routers/kimi-k2p5-turbo` (Kimi K2.5 Turbo, 262K context). Mirrors the existing Z.ai provider pattern, no special-casing needed in the rest of the app.
- **Unified web grounding via Exa** — new optional Exa API key field in settings. When set, the web-grounding toggle works for *every* provider/model (including Z.ai and Fireworks/Kimi which previously had no grounding option). Exa search results are injected into the system prompt and surfaced in the existing source-tile UI.
- **Refactor**: `AIConfig.supportsGrounding` (boolean) → `AIConfig.groundingMode` (`"off" | "native" | "exa"`). The enrich flow branches on the mode, with `exa` taking priority over the provider-native paths (`:online` for OpenRouter, `search-preview` for OpenAI). Exa search failures degrade gracefully — enrichment continues without grounding rather than erroring.
- CSP `connect-src` extended to allow `https://api.fireworks.ai` and `https://api.exa.ai`.
- `pnpm-lock.yaml` added to `.gitignore`.

### How grounding resolves now

| Provider | No Exa key | With Exa key |
|---|---|---|
| OpenRouter | Native ` :online` (existing) | Exa |
| OpenAI | Native `search-preview` variant (existing) | Exa |
| Z.ai | Toggle disabled | Exa |
| Fireworks (Kimi) | Toggle disabled | Exa |

## Test plan

- [ ] `pnpm dev`
- [ ] Settings → pick **Fireworks (Fire Pass)**, paste a Fireworks API key, model dropdown shows only "Kimi K2.5 Turbo"
- [ ] Without an Exa key, the Web Grounding toggle is disabled with hint text
- [ ] Paste an Exa API key → toggle becomes enabled with description "Live web search via Exa — works on any provider"
- [ ] Save and create a note like "What did the IPCC AR6 report say about 1.5°C?" — annotation should reflect Exa-sourced facts and source tiles should populate
- [ ] Switch back to OpenRouter without an Exa key → existing `:online` flow still works (regression check)
- [ ] Switch back to OpenRouter *with* an Exa key → grounding now goes through Exa instead of `:online` (resolved model id stays as the base id, not `…:online`)
- [ ] Repeat with OpenAI + GPT-4o (search-preview) and confirm both modes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)