### PR TITLE
Add chat panel, capture flow, and re-enrich button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 .claude/
 tsconfig.tsbuildinfo
 next-env.d.ts
+pnpm-lock.yaml
 
 # Internal docs
 CLAUDE.md

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,8 @@ import { GraphArea } from "@/components/graph-area"
 import { ProjectSidebar } from "@/components/project-sidebar"
 import { StatusBar } from "@/components/status-bar"
 import { GhostPanel, type GhostNote } from "@/components/ghost-panel"
+import { ChatPanel } from "@/components/chat-panel"
+import { sendChat, makeUserMessage, type ChatMessage } from "@/lib/ai-chat"
 import { VimInput } from "@/components/vim-input"
 import { IntroModal } from "@/components/intro-modal"
 import type { TextBlock } from "@/components/tile-card"
@@ -34,7 +36,11 @@ export interface Project {
   lastGhostTimestamp?: number
   /** Texts of recently generated ghost notes — passed back to the API to prevent near-duplicates */
   lastGhostTexts?: string[]
+  /** Per-project chat history, capped at MAX_CHAT_HISTORY messages with FIFO eviction */
+  chatMessages?: ChatMessage[]
 }
+
+const MAX_CHAT_HISTORY = 20
 
 import { TileIndex } from "@/components/tile-index"
 
@@ -46,6 +52,9 @@ export default function Page() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const [isIndexOpen, setIsIndexOpen] = useState(false)
   const [isGhostPanelOpen, setIsGhostPanelOpen] = useState(false)
+  const [isChatPanelOpen, setIsChatPanelOpen] = useState(false)
+  const [isChatWaiting, setIsChatWaiting] = useState(false)
+  const [chatError, setChatError] = useState<string | null>(null)
   const [viewMode, setViewMode] = useState<"tiling" | "kanban" | "graph">("tiling")
   const [isCommandKOpen, setIsCommandKOpen] = useState(false)
   const [jumpToSettings, setJumpToSettings] = useState(false)
@@ -533,6 +542,46 @@ export default function Page() {
     }))
   }, [updateActiveProject])
 
+  // ── Chat panel ───────────────────────────────────────────────────────────
+  const sendChatMessage = useCallback(async (text: string, includeCanvasContext: boolean) => {
+    if (!text.trim()) return
+    setChatError(null)
+    setIsChatWaiting(true)
+
+    const projectAtSendTime = projectsRef.current.find(p => p.id === activeProjectId)
+    const history = projectAtSendTime?.chatMessages ?? []
+    const canvasNotes = includeCanvasContext ? (projectAtSendTime?.blocks ?? []) : undefined
+
+    // Optimistically append the user message
+    const userMsg = makeUserMessage(text)
+    updateActiveProject(p => ({
+      ...p,
+      chatMessages: [...(p.chatMessages ?? []), userMsg].slice(-MAX_CHAT_HISTORY),
+    }))
+
+    try {
+      const assistantMsg = await sendChat({
+        history,
+        userMessage: text,
+        canvasContext: canvasNotes,
+      })
+      updateActiveProject(p => ({
+        ...p,
+        chatMessages: [...(p.chatMessages ?? []), assistantMsg].slice(-MAX_CHAT_HISTORY),
+      }))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setChatError(message)
+    } finally {
+      setIsChatWaiting(false)
+    }
+  }, [activeProjectId, updateActiveProject])
+
+  const clearChat = useCallback(() => {
+    setChatError(null)
+    updateActiveProject(p => ({ ...p, chatMessages: [] }))
+  }, [updateActiveProject])
+
   useEffect(() => {
     const handleKeys = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
@@ -550,6 +599,8 @@ export default function Page() {
       if (e.key === "Escape") {
         if (isCommandKOpen) {
           setIsCommandKOpen(false)
+        } else if (isChatPanelOpen) {
+          setIsChatPanelOpen(false)
         } else if (isGhostPanelOpen) {
           setIsGhostPanelOpen(false)
         }
@@ -557,7 +608,7 @@ export default function Page() {
     }
     window.addEventListener("keydown", handleKeys)
     return () => window.removeEventListener("keydown", handleKeys)
-  }, [isCommandKOpen, isGhostPanelOpen, undo])
+  }, [isCommandKOpen, isGhostPanelOpen, isChatPanelOpen, undo])
 
   const addBlock = useCallback(
     (text: string, forcedType?: ContentType) => {
@@ -615,6 +666,10 @@ export default function Page() {
     [activeProjectId, pushHistory, updateActiveProject, enrichBlock]
   )
 
+  const captureFromChat = useCallback((text: string) => {
+    addBlock(text)
+  }, [addBlock])
+
   const deleteBlock = useCallback((id: string) => {
     pushHistory(activeProjectId, blocksRef.current)
     updateActiveProject(p => ({
@@ -663,13 +718,18 @@ export default function Page() {
     const block = blocksRef.current.find(b => b.id === id)
     if (!block) return
 
+    // Snapshot current state so undo can restore the previous annotation,
+    // category, and contentType. Every caller (tile-card button, type changer,
+    // thesis refresh, chat capture) gets undo for free this way.
+    pushHistory(activeProjectId, blocksRef.current)
+
     updateActiveProject(p => ({
       ...p,
       blocks: p.blocks.map(b => b.id === id ? { ...b, category: newCategory, isEnriching: true } : b)
     }))
 
     enrichBlock(activeProjectId, id, block.text, newCategory || block.category, block.contentType).catch(console.error)
-  }, [activeProjectId, updateActiveProject, enrichBlock])
+  }, [activeProjectId, pushHistory, updateActiveProject, enrichBlock])
 
   const editAnnotation = useCallback((id: string, newAnnotation: string) => {
     updateActiveProject(p => ({
@@ -784,6 +844,10 @@ export default function Page() {
       setIsSidebarOpen(false)
       setIsIndexOpen(false)
       setIsGhostPanelOpen(prev => !prev)
+    } else if (cmd === "open-chat") {
+      setIsSidebarOpen(false)
+      setIsIndexOpen(false)
+      setIsChatPanelOpen(prev => !prev)
     } else if (cmd === "clear") clearBlocks()
     else if (cmd === "help") window.open("https://github.com/albingroen/react-cmdk", "_blank")
     
@@ -862,10 +926,13 @@ export default function Page() {
           isIndexOpen={isIndexOpen}
           isGhostPanelOpen={isGhostPanelOpen}
           ghostNoteCount={ghostNotes.filter(n => !n.isGenerating).length}
+          isChatPanelOpen={isChatPanelOpen}
+          chatMessageCount={(activeProject?.chatMessages ?? []).length}
           activeProjectName={activeProject?.name || ""}
           onMenuClick={() => setIsSidebarOpen(!isSidebarOpen)}
           onIndexToggle={() => setIsIndexOpen(!isIndexOpen)}
           onGhostPanelToggle={() => setIsGhostPanelOpen(prev => !prev)}
+          onChatPanelToggle={() => setIsChatPanelOpen(prev => !prev)}
           modelLabel={isHydrated && settings.apiKey ? currentModel.shortLabel : undefined}
           showHelpTooltip={showHelpTooltip}
           onHelpTooltipDismiss={() => {
@@ -950,6 +1017,20 @@ export default function Page() {
               <div className="h-full w-full" />
             )}
           </main>
+
+          <ChatPanel
+            isOpen={isChatPanelOpen}
+            onClose={() => setIsChatPanelOpen(false)}
+            messages={activeProject?.chatMessages ?? []}
+            onSend={sendChatMessage}
+            onCapture={captureFromChat}
+            onClear={clearChat}
+            isWaiting={isChatWaiting}
+            hasApiKey={Boolean(settings.apiKey)}
+            hasCanvasNotes={blocks.length > 0}
+            errorMessage={chatError}
+            onDismissError={() => setChatError(null)}
+          />
 
           <GhostPanel
             ghostNotes={ghostNotes}

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1,0 +1,339 @@
+"use client"
+
+import { useState, useRef, useEffect, KeyboardEvent } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+import { MessageSquare, X, Send, Plus, Layers, Loader2, Link as LinkIcon, AlertCircle } from "lucide-react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import type { ChatMessage } from "@/lib/ai-chat"
+
+interface ChatPanelProps {
+  isOpen: boolean
+  onClose: () => void
+  messages: ChatMessage[]
+  onSend: (text: string, includeCanvasContext: boolean) => Promise<void>
+  onCapture: (text: string) => void
+  onClear: () => void
+  isWaiting: boolean
+  hasApiKey: boolean
+  hasCanvasNotes: boolean
+  errorMessage?: string | null
+  onDismissError?: () => void
+}
+
+const MarkdownComponents = {
+  p: ({ children }: any) => <p className="mb-2 last:mb-0">{children}</p>,
+  ul: ({ children }: any) => <ul className="mb-2 list-disc pl-4 last:mb-0">{children}</ul>,
+  ol: ({ children }: any) => <ol className="mb-2 list-decimal pl-4 last:mb-0">{children}</ol>,
+  li: ({ children }: any) => <li className="mb-0.5">{children}</li>,
+  h1: ({ children }: any) => <h3 className="mb-1 text-[12px] font-bold">{children}</h3>,
+  h2: ({ children }: any) => <h3 className="mb-1 text-[12px] font-bold">{children}</h3>,
+  h3: ({ children }: any) => <h3 className="mb-1 text-[12px] font-bold">{children}</h3>,
+  strong: ({ children }: any) => <strong className="font-bold text-foreground">{children}</strong>,
+  em: ({ children }: any) => <em className="italic text-foreground/85">{children}</em>,
+  code: ({ children }: any) => (
+    <code className="rounded-sm bg-white/10 px-1 py-px font-mono text-[10px]">{children}</code>
+  ),
+  a: ({ href, children }: any) => (
+    <a href={href} target="_blank" rel="noopener noreferrer"
+       className="inline-flex items-center gap-0.5 text-primary hover:underline">
+      <LinkIcon className="h-2.5 w-2.5" />
+      {children}
+    </a>
+  ),
+}
+
+export function ChatPanel({
+  isOpen,
+  onClose,
+  messages,
+  onSend,
+  onCapture,
+  onClear,
+  isWaiting,
+  hasApiKey,
+  hasCanvasNotes,
+  errorMessage,
+  onDismissError,
+}: ChatPanelProps) {
+  const [input, setInput] = useState("")
+  const [includeContext, setIncludeContext] = useState(true)
+  const [capturingId, setCapturingId] = useState<string | null>(null)
+  const [captureDraft, setCaptureDraft] = useState("")
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Auto-scroll to the bottom whenever messages change or while waiting for a reply
+  useEffect(() => {
+    if (!scrollRef.current) return
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+  }, [messages, isWaiting])
+
+  // Auto-grow textarea up to a sensible cap
+  useEffect(() => {
+    if (!textareaRef.current) return
+    textareaRef.current.style.height = "auto"
+    textareaRef.current.style.height = Math.min(textareaRef.current.scrollHeight, 140) + "px"
+  }, [input])
+
+  const handleSend = async () => {
+    const trimmed = input.trim()
+    if (!trimmed || isWaiting || !hasApiKey) return
+    setInput("")
+    await onSend(trimmed, includeContext && hasCanvasNotes)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  const startCapture = (msg: ChatMessage) => {
+    setCapturingId(msg.id)
+    setCaptureDraft(msg.content)
+  }
+
+  const cancelCapture = () => {
+    setCapturingId(null)
+    setCaptureDraft("")
+  }
+
+  const confirmCapture = () => {
+    const text = captureDraft.trim()
+    if (text) {
+      onCapture(text)
+      cancelCapture()
+    }
+  }
+
+  return (
+    <div
+      style={{
+        width: isOpen ? 320 : 0,
+        opacity: isOpen ? 1 : 0,
+        visibility: isOpen ? "visible" : "hidden",
+      }}
+      className="flex flex-col h-full bg-black/20 backdrop-blur-3xl border-l border-border shrink-0 overflow-hidden relative z-50 transition-all duration-200 ease-in-out"
+    >
+      <div className="w-[320px] flex flex-col h-full">
+        {/* Header */}
+        <div className="flex h-10 items-center justify-between border-b border-border bg-card/5 px-3 py-1.5 shrink-0">
+          <div className="flex items-center gap-2">
+            <div className="flex items-center justify-center h-5 w-5 bg-primary/10 rounded-sm">
+              <MessageSquare className="h-3.5 w-3.5 text-primary" />
+            </div>
+            <h3 className="font-mono text-xs font-bold uppercase tracking-tight text-foreground/80 select-none">
+              Chat
+            </h3>
+            {messages.length > 0 && (
+              <span className="font-mono text-[9px] bg-primary/20 text-primary px-1.5 py-0.5 rounded-sm font-bold tabular-nums">
+                {messages.length}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            {messages.length > 0 && (
+              <button
+                onClick={onClear}
+                className="font-mono text-[9px] uppercase tracking-wider px-1.5 py-1 rounded-sm text-muted-foreground/40 hover:text-foreground hover:bg-white/5 transition-colors"
+                title="Clear conversation"
+              >
+                Clear
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="p-1 px-1.5 hover:bg-white/5 rounded-sm transition-colors text-muted-foreground/30 hover:text-white"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto custom-scrollbar py-3 px-3 space-y-3"
+        >
+          {messages.length === 0 && !isWaiting && (
+            <div className="flex flex-col items-center justify-center h-32 gap-3 opacity-25">
+              <MessageSquare className="h-5 w-5" />
+              <p className="font-mono text-[9px] uppercase tracking-[0.2em] text-center leading-relaxed">
+                Ask anything<br />about your notes
+              </p>
+            </div>
+          )}
+
+          <AnimatePresence initial={false}>
+            {messages.map(msg => (
+              <motion.div
+                key={msg.id}
+                initial={{ opacity: 0, y: -4 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.15 }}
+                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`max-w-[88%] rounded-md px-2.5 py-2 text-[12px] leading-relaxed ${
+                    msg.role === "user"
+                      ? "bg-primary/15 text-foreground border border-primary/20"
+                      : "bg-white/5 text-foreground/90 border border-white/5"
+                  }`}
+                >
+                  {msg.role === "user" ? (
+                    <p className="whitespace-pre-wrap">{msg.content}</p>
+                  ) : (
+                    <div className="prose-invert">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} components={MarkdownComponents}>
+                        {msg.content}
+                      </ReactMarkdown>
+                    </div>
+                  )}
+
+                  {/* Sources (Exa or native grounding) */}
+                  {msg.role === "assistant" && msg.sources && msg.sources.length > 0 && (
+                    <div className="mt-2 pt-2 border-t border-white/5 flex flex-wrap gap-1">
+                      {msg.sources.map((s, i) => (
+                        <a
+                          key={`${s.url}-${i}`}
+                          href={s.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 rounded-sm bg-white/5 hover:bg-white/10 px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground/80 hover:text-foreground transition-colors"
+                          title={s.title}
+                        >
+                          <LinkIcon className="h-2 w-2" />
+                          <span className="max-w-[100px] truncate">{s.siteName || s.title}</span>
+                        </a>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Capture controls (assistant messages only) */}
+                  {msg.role === "assistant" && (
+                    <div className="mt-2 pt-2 border-t border-white/5">
+                      {capturingId === msg.id ? (
+                        <div className="flex flex-col gap-1.5">
+                          <textarea
+                            value={captureDraft}
+                            onChange={e => setCaptureDraft(e.target.value)}
+                            className="w-full bg-black/30 border border-white/10 rounded-sm px-2 py-1.5 font-mono text-[10px] text-foreground outline-none focus:border-primary/40 resize-y min-h-[60px] custom-scrollbar"
+                            placeholder="Trim or edit before capturing…"
+                            autoFocus
+                          />
+                          <div className="flex items-center gap-1.5">
+                            <button
+                              onClick={confirmCapture}
+                              disabled={!captureDraft.trim()}
+                              className="flex items-center gap-1 px-2 py-1 rounded-sm bg-primary/20 hover:bg-primary/30 disabled:opacity-30 disabled:cursor-not-allowed font-mono text-[9px] font-bold uppercase tracking-wider text-primary transition-colors"
+                            >
+                              <Plus className="h-2.5 w-2.5" />
+                              Add to canvas
+                            </button>
+                            <button
+                              onClick={cancelCapture}
+                              className="px-2 py-1 rounded-sm hover:bg-white/5 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/60 hover:text-foreground transition-colors"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => startCapture(msg)}
+                          className="flex items-center gap-1 px-1.5 py-0.5 rounded-sm hover:bg-white/5 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/50 hover:text-primary transition-colors"
+                        >
+                          <Plus className="h-2.5 w-2.5" />
+                          Capture
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </motion.div>
+            ))}
+          </AnimatePresence>
+
+          {isWaiting && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="flex justify-start"
+            >
+              <div className="rounded-md px-2.5 py-2 bg-white/5 border border-white/5 flex items-center gap-2">
+                <Loader2 className="h-3 w-3 animate-spin text-primary/60" />
+                <span className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground/50">
+                  Thinking…
+                </span>
+              </div>
+            </motion.div>
+          )}
+        </div>
+
+        {/* Error banner */}
+        {errorMessage && (
+          <div className="mx-3 mb-2 flex items-start gap-2 rounded-sm border border-destructive/30 bg-destructive/10 px-2 py-1.5">
+            <AlertCircle className="h-3 w-3 text-destructive shrink-0 mt-0.5" />
+            <p className="flex-1 font-mono text-[9px] text-destructive leading-relaxed break-words">
+              {errorMessage}
+            </p>
+            {onDismissError && (
+              <button
+                onClick={onDismissError}
+                className="text-destructive/60 hover:text-destructive transition-colors shrink-0"
+              >
+                <X className="h-2.5 w-2.5" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Footer: input + canvas context toggle */}
+        <div className="border-t border-border bg-card/5 p-3 shrink-0">
+          {!hasApiKey && (
+            <p className="mb-2 font-mono text-[9px] text-destructive/80 leading-relaxed">
+              Add an API key in Settings to start chatting.
+            </p>
+          )}
+          <div className="flex items-end gap-2">
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={!hasApiKey || isWaiting}
+              placeholder={isWaiting ? "Waiting for reply…" : "Ask a question…"}
+              rows={1}
+              className="flex-1 min-h-[32px] max-h-[140px] resize-none rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-2 font-mono text-[11px] text-foreground outline-none focus:border-primary/40 placeholder:text-muted-foreground/30 disabled:opacity-50 custom-scrollbar"
+            />
+            <button
+              onClick={handleSend}
+              disabled={!input.trim() || isWaiting || !hasApiKey}
+              className="shrink-0 flex h-8 w-8 items-center justify-center rounded-md bg-primary/20 hover:bg-primary/30 disabled:opacity-30 disabled:cursor-not-allowed text-primary transition-colors"
+              title="Send (Enter)"
+            >
+              <Send className="h-3.5 w-3.5" />
+            </button>
+          </div>
+
+          {/* Canvas context toggle */}
+          <button
+            onClick={() => setIncludeContext(v => !v)}
+            disabled={!hasCanvasNotes}
+            className="mt-2 flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/50 hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            title={hasCanvasNotes ? "Toggle canvas context" : "No notes on canvas to include"}
+          >
+            <div className={`flex h-3 w-3 items-center justify-center rounded-sm border ${
+              includeContext && hasCanvasNotes ? "border-primary bg-primary/30" : "border-white/15"
+            }`}>
+              {includeContext && hasCanvasNotes && <Layers className="h-2 w-2 text-primary" />}
+            </div>
+            Include canvas context
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/project-sidebar.tsx
+++ b/components/project-sidebar.tsx
@@ -71,6 +71,7 @@ export function ProjectSidebar({
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [showSettings, setShowSettings] = useState(false)
   const [showKey, setShowKey] = useState(false)
+  const [showExaKey, setShowExaKey] = useState(false)
   const [modelOpen, setModelOpen] = useState(false)
   const [providerOpen, setProviderOpen] = useState(false)
   // local draft for settings (only save on "Save")
@@ -110,11 +111,12 @@ export function ProjectSidebar({
   const persistSettings = () => {
     // Trim key to strip accidental whitespace/newlines from paste
     const trimmedKey = draft.apiKey.trim()
+    const trimmedExaKey = (draft.exaApiKey ?? "").trim()
     const providerKeys: Partial<Record<AIProvider, string>> = {
       ...(draft.providerKeys ?? {}),
       [draft.provider]: trimmedKey,
     }
-    onUpdateAISettings({ ...draft, apiKey: trimmedKey, providerKeys })
+    onUpdateAISettings({ ...draft, apiKey: trimmedKey, exaApiKey: trimmedExaKey, providerKeys })
   }
 
   const handleSaveSettings = () => {
@@ -447,35 +449,80 @@ export function ProjectSidebar({
                   )}
                 </div>
 
-                {/* Web Grounding (OpenRouter + OpenAI) */}
-                {(draft.provider === "openrouter" || draft.provider === "openai") && selectedModel && (
-                  <div className="flex items-start justify-between gap-3 rounded-md border border-white/5 bg-white/[0.02] px-2.5 py-2.5">
-                    <div className="flex items-start gap-2">
-                      <Globe className="h-3.5 w-3.5 mt-0.5 text-primary/60 shrink-0" />
-                      <div>
-                        <div className="font-mono text-[11px] font-bold text-foreground">Web Grounding</div>
-                        <div className="font-mono text-[9px] text-muted-foreground mt-0.5 leading-relaxed">
-                          {selectedModel.supportsGrounding
-                            ? draft.provider === "openai"
-                              ? `Uses ${selectedModel.groundingModelId ?? "search-preview"} for live web access`
-                              : "Adds :online for live search"
-                            : "Not available for this model"}
+                {/* Web Grounding — works for any provider when an Exa key is set,
+                    falls back to OpenRouter/OpenAI native search variants otherwise. */}
+                {(() => {
+                  const exaConfigured = (draft.exaApiKey ?? "").trim().length > 0
+                  const nativeAvailable =
+                    (draft.provider === "openrouter" || draft.provider === "openai") &&
+                    (selectedModel?.supportsGrounding ?? false)
+                  const groundingAvailable = exaConfigured || nativeAvailable
+                  const effectivelyOn = draft.webGrounding && groundingAvailable
+                  const description = exaConfigured
+                    ? "Live web search via Exa — works on any provider"
+                    : nativeAvailable
+                      ? draft.provider === "openai"
+                        ? `Uses ${selectedModel?.groundingModelId ?? "search-preview"} for live web access`
+                        : "Adds :online for live search"
+                      : "Add an Exa key below to enable grounding for this provider"
+
+                  if (!selectedModel) return null
+
+                  return (
+                    <div className="flex items-start justify-between gap-3 rounded-md border border-white/5 bg-white/[0.02] px-2.5 py-2.5">
+                      <div className="flex items-start gap-2">
+                        <Globe className="h-3.5 w-3.5 mt-0.5 text-primary/60 shrink-0" />
+                        <div>
+                          <div className="font-mono text-[11px] font-bold text-foreground">Web Grounding</div>
+                          <div className="font-mono text-[9px] text-muted-foreground mt-0.5 leading-relaxed">
+                            {description}
+                          </div>
                         </div>
                       </div>
+                      <button
+                        onClick={() => groundingAvailable && setDraft(d => ({ ...d, webGrounding: !d.webGrounding }))}
+                        disabled={!groundingAvailable}
+                        className={`relative shrink-0 h-5 w-9 rounded-full transition-all duration-200 ${
+                          effectivelyOn ? "bg-primary" : "bg-white/10"
+                        } disabled:opacity-30 disabled:cursor-not-allowed`}
+                      >
+                        <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all duration-200 ${
+                          effectivelyOn ? "left-5" : "left-0.5"
+                        }`} />
+                      </button>
                     </div>
-                    <button
-                      onClick={() => selectedModel.supportsGrounding && setDraft(d => ({ ...d, webGrounding: !d.webGrounding }))}
-                      disabled={!selectedModel.supportsGrounding}
-                      className={`relative shrink-0 h-5 w-9 rounded-full transition-all duration-200 ${
-                        draft.webGrounding && selectedModel.supportsGrounding ? "bg-primary" : "bg-white/10"
-                      } disabled:opacity-30 disabled:cursor-not-allowed`}
-                    >
-                      <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all duration-200 ${
-                        draft.webGrounding && selectedModel.supportsGrounding ? "left-5" : "left-0.5"
-                      }`} />
+                  )
+                })()}
+
+                {/* Exa Search Key — optional, unlocks grounding for any provider */}
+                <div className="flex flex-col gap-2">
+                  <label className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+                    Exa Key · Web Search (optional)
+                  </label>
+                  <div className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-2 focus-within:border-primary/50 transition-colors">
+                    <Globe className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    <input
+                      type="text"
+                      value={draft.exaApiKey ?? ""}
+                      onChange={e => setDraft(d => ({ ...d, exaApiKey: e.target.value }))}
+                      placeholder="Your Exa API key"
+                      className="flex-1 bg-transparent font-mono text-[11px] text-foreground outline-none placeholder:text-muted-foreground/40"
+                      style={showExaKey ? undefined : { WebkitTextSecurity: "disc" } as never}
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                    <button onClick={() => setShowExaKey(v => !v)} className="text-muted-foreground hover:text-foreground transition-colors">
+                      {showExaKey ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
                     </button>
                   </div>
-                )}
+                  <p className="font-mono text-[9px] text-muted-foreground leading-relaxed">
+                    Enables web grounding for every provider via Exa search. Stored locally.{" "}
+                    <a href="https://dashboard.exa.ai/api-keys" target="_blank" rel="noopener noreferrer"
+                      className="text-primary underline hover:brightness-125 transition-all">
+                      Get a key →
+                    </a>
+                  </p>
+                </div>
 
                 {/* API Status */}
                 <div className={`flex items-center gap-2 rounded-md px-2.5 py-2 font-mono text-[9px] ${

--- a/components/status-bar.tsx
+++ b/components/status-bar.tsx
@@ -6,7 +6,7 @@ import { CONTENT_TYPE_CONFIG } from "@/lib/content-types"
 import type { TextBlock } from "@/components/tile-card"
 import { AboutPanel } from "@/components/about-panel"
 
-import { Menu, LayoutList, Sparkles } from "lucide-react"
+import { Menu, LayoutList, Sparkles, MessageSquare } from "lucide-react"
 
 interface StatusBarProps {
   blockCount: number
@@ -16,9 +16,12 @@ interface StatusBarProps {
   isIndexOpen: boolean
   isGhostPanelOpen: boolean
   ghostNoteCount: number
+  isChatPanelOpen: boolean
+  chatMessageCount: number
   onMenuClick: () => void
   onIndexToggle: () => void
   onGhostPanelToggle: () => void
+  onChatPanelToggle: () => void
   modelLabel?: string
   showHelpTooltip?: boolean
   onHelpTooltipDismiss?: () => void
@@ -32,9 +35,12 @@ export function StatusBar({
   isIndexOpen,
   isGhostPanelOpen,
   ghostNoteCount,
+  isChatPanelOpen,
+  chatMessageCount,
   onMenuClick,
   onIndexToggle,
   onGhostPanelToggle,
+  onChatPanelToggle,
   modelLabel,
   showHelpTooltip,
   onHelpTooltipDismiss,
@@ -163,6 +169,24 @@ export function StatusBar({
           <span className="font-mono text-[10px] text-muted-foreground tabular-nums" suppressHydrationWarning>
             {time}
           </span>
+          {/* Chat panel toggle with badge */}
+          <button
+            onClick={onChatPanelToggle}
+            className={`relative p-1.5 rounded-sm transition-all duration-200 ${
+              isChatPanelOpen
+                ? "bg-primary/20 text-primary shadow-[inset_0_1px_2px_rgba(0,0,0,0.2)]"
+                : "hover:bg-secondary text-muted-foreground/50 hover:text-foreground"
+            }`}
+            title="Chat Panel"
+          >
+            <MessageSquare className="h-4 w-4" />
+            {chatMessageCount > 0 && !isChatPanelOpen && (
+              <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary font-mono text-[7px] font-black text-primary-foreground">
+                {chatMessageCount}
+              </span>
+            )}
+          </button>
+
           {/* Ghost panel toggle with badge */}
           <button
             onClick={onGhostPanelToggle}

--- a/components/tile-card.tsx
+++ b/components/tile-card.tsx
@@ -419,6 +419,22 @@ export const TileCard = memo(function TileCard({
               <Tag className="h-2.5 w-2.5" />
             </button>
           )}
+          {/* Re-enrich button — runs the annotation pass again. Pushes an undo
+              snapshot in the parent so Cmd+Z restores the previous annotation. */}
+          {!effectiveCollapsed && block.contentType !== "thesis" && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onReEnrich(block.id)
+              }}
+              disabled={block.isEnriching}
+              className="flex h-4 w-4 items-center justify-center rounded-sm transition-all opacity-40 hover:opacity-100 hover:bg-black/10 disabled:cursor-not-allowed"
+              title="Re-enrich (undoable)"
+              aria-label="Re-enrich note"
+            >
+              <RefreshCw className={`h-2.5 w-2.5 ${block.isEnriching ? "animate-spin opacity-50" : ""}`} />
+            </button>
+          )}
           <button
             onClick={(e) => {
               e.stopPropagation()

--- a/components/vim-input.tsx
+++ b/components/vim-input.tsx
@@ -5,7 +5,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import {
   Trello, Grid, Trash2, Clipboard, Download,
   FolderOpen, FolderPlus, BookOpen, Sparkles,
-  FolderDown, FolderInput, GitFork
+  FolderDown, FolderInput, GitFork, MessageSquare
 } from "lucide-react"
 import { Command } from "cmdk"
 import { useModKey } from "@/lib/utils"
@@ -48,10 +48,11 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
   ], [])
 
   const NAV_ITEMS = React.useMemo(() => [
-    { id: "open-projects",  icon: FolderOpen, label: "Projects",    sub: "" },
-    { id: "new-project",    icon: FolderPlus, label: "New Project", sub: "" },
-    { id: "open-index",     icon: BookOpen,   label: "Index",       sub: "" },
-    { id: "open-synthesis", icon: Sparkles,   label: "Synthesis",   sub: "" },
+    { id: "open-projects",  icon: FolderOpen,    label: "Projects",    sub: "" },
+    { id: "new-project",    icon: FolderPlus,    label: "New Project", sub: "" },
+    { id: "open-index",     icon: BookOpen,      label: "Index",       sub: "" },
+    { id: "open-synthesis", icon: Sparkles,      label: "Synthesis",   sub: "" },
+    { id: "open-chat",      icon: MessageSquare, label: "Chat",        sub: "" },
   ], [])
 
   // ── Filtered items ──────────────────────────────────────────────────────

--- a/lib/ai-chat.ts
+++ b/lib/ai-chat.ts
@@ -1,0 +1,164 @@
+"use client"
+
+import { loadAIConfig, getBaseUrl, getProviderHeaders, getModelsForProvider } from "@/lib/ai-settings"
+import { exaSearch, formatExaResultsForPrompt } from "@/lib/web-search"
+import { parseProviderError } from "@/lib/ai-enrich"
+import type { TextBlock } from "@/components/tile-card"
+
+export interface ChatMessage {
+  id: string
+  role: "user" | "assistant"
+  content: string
+  timestamp: number
+  /** Source tiles populated when this message was grounded (Exa or native) */
+  sources?: { url: string; title: string; siteName: string }[]
+}
+
+export interface SendChatOptions {
+  /** Conversation history excluding the new user message */
+  history: ChatMessage[]
+  /** The new user message */
+  userMessage: string
+  /** Optional canvas notes to include as context */
+  canvasContext?: TextBlock[]
+}
+
+const SYSTEM_PROMPT = `You are a thinking partner embedded in a notetaking tool called nodepad.
+
+Be concise and substantive. Default to 2–4 sentences unless the user explicitly asks for depth. Use markdown sparingly: **bold** for key terms, *italic* for titles, fenced code blocks only for actual code.
+
+When the user includes a "Current canvas notes" block below, treat it as the user's working context — reference specific notes by their topic when relevant, surface contradictions or gaps, suggest connections. Never quote them verbatim back at the user; they wrote them.
+
+If web search results appear in a <search_results> block, treat them as the primary evidence for factual claims and cite sources by name only (e.g. "Per LitCharts" or "Per the IPCC AR6 report"). Never fabricate or guess URLs.`
+
+const MAX_CONTEXT_NOTES = 12
+const MAX_NOTE_TEXT = 240
+const MAX_NOTE_ANNOTATION = 200
+
+function buildCanvasContext(notes: TextBlock[]): string {
+  if (!notes || notes.length === 0) return ""
+  const trimmed = notes.slice(0, MAX_CONTEXT_NOTES).map((n, i) => {
+    const text = n.text.length > MAX_NOTE_TEXT ? n.text.slice(0, MAX_NOTE_TEXT) + "…" : n.text
+    const ann = n.annotation
+      ? `\n    → ${n.annotation.length > MAX_NOTE_ANNOTATION ? n.annotation.slice(0, MAX_NOTE_ANNOTATION) + "…" : n.annotation}`
+      : ""
+    return `[${i + 1}] (${n.contentType}) ${text}${ann}`
+  })
+  return `\n\n## Current canvas notes\n${trimmed.join("\n")}`
+}
+
+function generateMessageId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+export async function sendChat({ history, userMessage, canvasContext }: SendChatOptions): Promise<ChatMessage> {
+  const config = loadAIConfig()
+  if (!config) throw new Error("No API key configured. Open Settings to add one.")
+
+  // Optional Exa grounding — same shape as ai-enrich. Failures degrade silently
+  // so a flaky search backend never blocks the chat reply.
+  let exaContext = ""
+  let exaSources: { url: string; title: string; siteName: string }[] = []
+  if (config.groundingMode === "exa") {
+    try {
+      const results = await exaSearch(userMessage.trim().slice(0, 500), config.exaApiKey, 5)
+      exaContext = formatExaResultsForPrompt(results)
+      exaSources = results.map(r => {
+        let siteName = ""
+        try { siteName = new URL(r.url).hostname.replace(/^www\./, "") } catch { /* ignore */ }
+        return { url: r.url, title: r.title || siteName, siteName }
+      })
+    } catch (err) {
+      console.warn("[ai-chat] Exa search failed, continuing without grounding:", err)
+    }
+  }
+
+  const canvasBlock = canvasContext ? buildCanvasContext(canvasContext) : ""
+  const systemPrompt = SYSTEM_PROMPT + canvasBlock + exaContext
+
+  // Native grounding rewrites the model id (OpenRouter `:online`, OpenAI search-preview).
+  let model = config.modelId
+  let webSearchOptions: Record<string, unknown> | undefined
+  if (config.groundingMode === "native") {
+    if (config.provider === "openrouter") {
+      if (!model.endsWith(":online")) model = `${model}:online`
+    } else if (config.provider === "openai") {
+      const modelDef = getModelsForProvider("openai").find(m => m.id === config.modelId)
+      if (modelDef?.groundingModelId) model = modelDef.groundingModelId
+      webSearchOptions = {}
+    }
+  }
+
+  const messages = [
+    { role: "system" as const, content: systemPrompt },
+    ...history.map(m => ({ role: m.role, content: m.content })),
+    { role: "user" as const, content: userMessage },
+  ]
+
+  const baseUrl = getBaseUrl(config)
+  const response = await fetch(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: getProviderHeaders(config),
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: 1500,
+      ...(webSearchOptions === undefined
+        ? { temperature: 0.5 }
+        : { web_search_options: webSearchOptions }),
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(await parseProviderError(response))
+  }
+
+  const data = (await response.json().catch(() => null)) as Record<string, unknown> | null
+  const choices = data?.choices as
+    | Array<{ message?: { content?: string; annotations?: unknown[] } }>
+    | undefined
+  const content = choices?.[0]?.message?.content
+  if (!content) throw new Error("No content in chat response")
+
+  // Extract native citations (OpenRouter :online and OpenAI search-preview both
+  // attach url_citation annotations on the message).
+  const annotations =
+    (choices?.[0]?.message?.annotations ?? []) as Array<{
+      type: string
+      url_citation?: { url: string; title?: string }
+    }>
+  const seen = new Set<string>()
+  const nativeSources = annotations
+    .filter(a => a.type === "url_citation" && a.url_citation?.url)
+    .map(a => {
+      const { url, title } = a.url_citation!
+      let siteName = ""
+      try { siteName = new URL(url).hostname.replace(/^www\./, "") } catch { /* ignore */ }
+      return { url, title: title || siteName, siteName }
+    })
+    .filter(s => {
+      if (seen.has(s.url)) return false
+      seen.add(s.url)
+      return true
+    })
+
+  const finalSources =
+    nativeSources.length > 0 ? nativeSources : exaSources.length > 0 ? exaSources : undefined
+
+  return {
+    id: generateMessageId(),
+    role: "assistant",
+    content,
+    timestamp: Date.now(),
+    sources: finalSources,
+  }
+}
+
+export function makeUserMessage(content: string): ChatMessage {
+  return {
+    id: generateMessageId(),
+    role: "user",
+    content,
+    timestamp: Date.now(),
+  }
+}

--- a/lib/ai-enrich.ts
+++ b/lib/ai-enrich.ts
@@ -2,6 +2,7 @@
 
 import { detectContentType } from "@/lib/detect-content-type"
 import { loadAIConfig, getBaseUrl, getProviderHeaders, getModelsForProvider } from "@/lib/ai-settings"
+import { exaSearch, formatExaResultsForPrompt, type WebSearchResult } from "@/lib/web-search"
 import type { ContentType } from "@/lib/content-types"
 
 // ── Provider error parser ─────────────────────────────────────────────────────
@@ -265,17 +266,31 @@ export async function enrichBlockClient(
 
   const detectedType = detectContentType(text)
   const effectiveType = forcedType || detectedType
-  const shouldGround = config.supportsGrounding && TRUTH_DEPENDENT_TYPES.has(effectiveType)
+  const wantsGround = config.groundingMode !== "off" && TRUTH_DEPENDENT_TYPES.has(effectiveType)
 
   let model = config.modelId
   let webSearchOptions: Record<string, unknown> | undefined
-  if (shouldGround) {
-    if (config.provider === "openrouter") {
-      if (!model.endsWith(":online")) model = `${model}:online`
-    } else if (config.provider === "openai") {
-      const modelDef = getModelsForProvider("openai").find(m => m.id === config.modelId)
-      if (modelDef?.groundingModelId) model = modelDef.groundingModelId
-      webSearchOptions = {}
+  let exaContext = ""
+  let exaResults: WebSearchResult[] = []
+
+  if (wantsGround) {
+    if (config.groundingMode === "exa") {
+      // Search Exa with a trimmed version of the note so the query stays focused.
+      // Failure here should NOT block enrichment — fall through ungrounded.
+      try {
+        exaResults = await exaSearch(text.trim().slice(0, 500), config.exaApiKey, 5)
+        exaContext = formatExaResultsForPrompt(exaResults)
+      } catch (err) {
+        console.warn("[ai-enrich] Exa search failed, continuing without grounding:", err)
+      }
+    } else if (config.groundingMode === "native") {
+      if (config.provider === "openrouter") {
+        if (!model.endsWith(":online")) model = `${model}:online`
+      } else if (config.provider === "openai") {
+        const modelDef = getModelsForProvider("openai").find(m => m.id === config.modelId)
+        if (modelDef?.groundingModelId) model = modelDef.groundingModelId
+        webSearchOptions = {}
+      }
     }
   }
 
@@ -284,7 +299,10 @@ export async function enrichBlockClient(
   // fall back to json_object mode (guaranteed valid JSON, no schema enforcement)
   const useStrictSchema = supportsJsonSchema && !webSearchOptions
 
-  const groundingNote = shouldGround
+  // Native grounding tells the model "you have live web access" generically.
+  // Exa grounding injects actual results via exaContext, which already includes
+  // its own citation instructions, so we skip the generic note in that case.
+  const groundingNote = wantsGround && config.groundingMode === "native"
     ? `\n\n## Source Citations (grounded search active)
 You have live web access. For this note type, include 1–2 real source citations by name, publication, and year. Do NOT generate URLs — reference by title and author only (e.g. "Per *Science*, 2023, Doe et al."). Only cite sources you have actually retrieved.`
     : ""
@@ -297,7 +315,7 @@ You have live web access. For this note type, include 1–2 real source citation
     ? `\n\n## Output Format — CRITICAL\nYou MUST respond with a single JSON object (no markdown, no explanation). Schema:\n${JSON.stringify(JSON_SCHEMA.schema, null, 2)}`
     : ""
 
-  const systemPrompt = SYSTEM_PROMPT + groundingNote + schemaHint
+  const systemPrompt = SYSTEM_PROMPT + groundingNote + exaContext + schemaHint
 
   const categoryContext = category
     ? `\n\nThe user has assigned this note the category "${category}".`
@@ -418,7 +436,17 @@ You have live web access. For this note type, include 1–2 real source citation
       return true
     })
 
-  if (sources.length > 0) result.sources = sources
+  if (sources.length > 0) {
+    result.sources = sources
+  } else if (exaResults.length > 0) {
+    // Exa grounding path: results are not on `message.annotations`; build the
+    // tile-card source list from the search response we already have.
+    result.sources = exaResults.map(r => {
+      let siteName = ""
+      try { siteName = new URL(r.url).hostname.replace(/^www\./, "") } catch { /* ignore */ }
+      return { url: r.url, title: r.title || siteName, siteName }
+    })
+  }
 
   return result
 }

--- a/lib/ai-settings.ts
+++ b/lib/ai-settings.ts
@@ -12,7 +12,7 @@ export interface AIModel {
   groundingModelId?: string
 }
 
-export type AIProvider = "openrouter" | "openai" | "zai"
+export type AIProvider = "openrouter" | "openai" | "zai" | "fireworks"
 
 export interface AIProviderPreset {
   id: AIProvider
@@ -43,6 +43,13 @@ export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
     baseUrl: "https://api.z.ai/api/paas/v4",
     keyUrl: "https://z.ai/manage-apikey/apikey-list",
     keyPlaceholder: "Your Z.ai API key",
+  },
+  {
+    id: "fireworks",
+    label: "Fireworks (Fire Pass)",
+    baseUrl: "https://api.fireworks.ai/inference/v1",
+    keyUrl: "https://fireworks.ai/account/api-keys",
+    keyPlaceholder: "fw-...",
   },
 ]
 
@@ -174,9 +181,20 @@ export const ZAI_MODELS: AIModel[] = [
   },
 ]
 
+export const FIREWORKS_MODELS: AIModel[] = [
+  {
+    id: "accounts/fireworks/routers/kimi-k2p5-turbo",
+    label: "Kimi K2.5 Turbo",
+    shortLabel: "Kimi K2.5",
+    description: "Fire Pass · 262K context · tools + vision",
+    supportsGrounding: false,
+  },
+]
+
 export function getModelsForProvider(provider: AIProvider): AIModel[] {
-  if (provider === "openai") return OPENAI_MODELS
-  if (provider === "zai")    return ZAI_MODELS
+  if (provider === "openai")    return OPENAI_MODELS
+  if (provider === "zai")       return ZAI_MODELS
+  if (provider === "fireworks") return FIREWORKS_MODELS
   return AI_MODELS // openrouter + safe fallback for any stale localStorage value
 }
 
@@ -191,29 +209,40 @@ export interface AISettings {
   customBaseUrl: string
   /** Per-provider key store so switching back to a provider restores its key */
   providerKeys?: Partial<Record<AIProvider, string>>
+  /** Optional Exa API key. When set, web grounding works for ANY provider/model
+   *  via Exa search results injected into the system prompt — bypassing the
+   *  provider-specific search variants used by OpenAI/OpenRouter. */
+  exaApiKey: string
 }
+
+/** Which web-grounding strategy applies for this request:
+ *  - off:    no grounding
+ *  - native: provider has a hosted search variant (OpenAI search-preview, OpenRouter `:online`)
+ *  - exa:    user has an Exa key — works for every provider */
+export type GroundingMode = "off" | "native" | "exa"
 
 const STORAGE_KEY = "nodepad-ai-settings"
 
 function loadSettings(): AISettings {
   if (typeof window === "undefined") {
-    return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "" }
+    return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "", exaApiKey: "" }
   }
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "" }
+    if (!raw) return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "", exaApiKey: "" }
     return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "", ...JSON.parse(raw) }
   } catch {
-    return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "" }
+    return { apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false, provider: DEFAULT_PROVIDER, customBaseUrl: "", exaApiKey: "" }
   }
 }
 
 export interface AIConfig {
   apiKey: string
   modelId: string
-  supportsGrounding: boolean
+  groundingMode: GroundingMode
   provider: AIProvider
   customBaseUrl: string
+  exaApiKey: string
 }
 
 export function loadAIConfig(): AIConfig | null {
@@ -226,12 +255,34 @@ export function loadAIConfig(): AIConfig | null {
   // OpenRouter-prefixed id (e.g. "openai/gpt-4o") after switching to OpenAI —
   // that string won't match any entry in OPENAI_MODELS so we fall back to "gpt-4o".
   const modelId = model?.id ?? models[0]?.id ?? s.modelId ?? DEFAULT_MODEL_ID
-  // Z.ai does not support grounding; only openrouter and openai do
-  const supportsGrounding =
-    (s.provider === "openrouter" || s.provider === "openai") &&
-    s.webGrounding &&
-    (model?.supportsGrounding ?? false)
-  return { apiKey: s.apiKey, modelId, supportsGrounding, provider: s.provider, customBaseUrl: s.customBaseUrl }
+  const exaApiKey = (s.exaApiKey ?? "").trim()
+
+  // Grounding mode resolution:
+  //  1. If toggle is off → "off".
+  //  2. If user has an Exa key → "exa" (works for every provider/model).
+  //  3. Otherwise fall back to the provider's native search variant when available
+  //     (OpenAI search-preview models, OpenRouter `:online`).
+  //  4. Else "off" — toggle is on but nothing can fulfil it (UI surfaces this).
+  let groundingMode: GroundingMode = "off"
+  if (s.webGrounding) {
+    if (exaApiKey) {
+      groundingMode = "exa"
+    } else if (
+      (s.provider === "openrouter" || s.provider === "openai") &&
+      (model?.supportsGrounding ?? false)
+    ) {
+      groundingMode = "native"
+    }
+  }
+
+  return {
+    apiKey: s.apiKey,
+    modelId,
+    groundingMode,
+    provider: s.provider,
+    customBaseUrl: s.customBaseUrl,
+    exaApiKey,
+  }
 }
 
 export function getBaseUrl(config: AIConfig): string {
@@ -271,7 +322,7 @@ export function useAISettings() {
   // modelLabel prop, etc.) between the server render and client hydration.
   const [settings, setSettings] = useState<AISettings>({
     apiKey: "", modelId: DEFAULT_MODEL_ID, webGrounding: false,
-    provider: DEFAULT_PROVIDER, customBaseUrl: "",
+    provider: DEFAULT_PROVIDER, customBaseUrl: "", exaApiKey: "",
   })
   const [isHydrated, setIsHydrated] = useState(false)
 
@@ -293,7 +344,15 @@ export function useAISettings() {
   const resolvedModelId = (() => {
     const model = models.find(m => m.id === settings.modelId) || models[0]
     if (!model) return settings.modelId
-    if (settings.provider === "openrouter" && settings.webGrounding && model.supportsGrounding) {
+    // Only append `:online` for OpenRouter's native grounding path. When an Exa
+    // key is present we ground through Exa instead and the base model id stays.
+    const exaConfigured = (settings.exaApiKey ?? "").trim().length > 0
+    if (
+      settings.provider === "openrouter" &&
+      settings.webGrounding &&
+      model.supportsGrounding &&
+      !exaConfigured
+    ) {
       return `${model.id}:online`
     }
     return model.id

--- a/lib/web-search.ts
+++ b/lib/web-search.ts
@@ -1,0 +1,72 @@
+// Lightweight Exa search adapter for unified web grounding across any AI provider.
+// Called directly from the browser — Exa allows CORS and the API key stays in
+// localStorage like every other key in the app.
+
+export interface WebSearchResult {
+  title: string
+  url: string
+  snippet: string
+  publishedDate?: string
+}
+
+export async function exaSearch(
+  query: string,
+  apiKey: string,
+  numResults = 5,
+): Promise<WebSearchResult[]> {
+  const trimmedQuery = query.trim()
+  if (!trimmedQuery || !apiKey) return []
+
+  const res = await fetch("https://api.exa.ai/search", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: trimmedQuery,
+      type: "auto",
+      num_results: numResults,
+      contents: { highlights: { max_characters: 1200 } },
+    }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`Exa search failed (${res.status}): ${body || res.statusText}`)
+  }
+
+  const data = (await res.json().catch(() => null)) as { results?: unknown } | null
+  const raw = Array.isArray(data?.results) ? (data!.results as unknown[]) : []
+
+  return raw
+    .map((r) => {
+      const o = r as Record<string, unknown>
+      const highlights = Array.isArray(o.highlights)
+        ? (o.highlights as unknown[]).map(String)
+        : []
+      return {
+        title: String(o.title ?? ""),
+        url: String(o.url ?? ""),
+        snippet: highlights.join(" … ").trim(),
+        publishedDate: typeof o.publishedDate === "string" ? o.publishedDate : undefined,
+      }
+    })
+    .filter((r) => r.url)
+}
+
+export function formatExaResultsForPrompt(results: WebSearchResult[]): string {
+  if (results.length === 0) return ""
+  const block = results
+    .map((r, i) => {
+      const date = r.publishedDate ? ` (${r.publishedDate.slice(0, 10)})` : ""
+      return `[${i + 1}] ${r.title}${date}\n${r.url}\n${r.snippet}`
+    })
+    .join("\n\n")
+  return `\n\n## Live Web Search Results
+The following sources were retrieved live for this query via web search. Treat them as the primary evidence for any factual claims in your annotation. Cite sources by name only (e.g. "Per LitCharts" or "Per the Studypool summary"). Never generate or guess URLs — the user sees the source list separately as clickable links.
+
+<search_results>
+${block}
+</search_results>`
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -47,7 +47,7 @@ const nextConfig = {
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cloud.umami.is",
               "style-src 'self' 'unsafe-inline'",
-              "connect-src 'self' https://openrouter.ai https://api.openai.com https://api.z.ai https://cloud.umami.is https://api-gateway.umami.dev",
+              "connect-src 'self' https://openrouter.ai https://api.openai.com https://api.z.ai https://api.fireworks.ai https://api.exa.ai https://cloud.umami.is https://api-gateway.umami.dev",
               "img-src 'self' data: blob: https://i.ytimg.com",
               "font-src 'self' data:",
               "frame-src https://www.youtube-nocookie.com https://www.youtube.com",


### PR DESCRIPTION
## Summary

A stackable **Chat panel** that lives next to the existing Synthesis panel, plus a long-overdue **Re-enrich button** on every tile.

> ⚠️ **Depends on #24** (Fireworks + Exa-based grounding). The diff in this PR currently includes the #24 commits — once #24 lands the diff will collapse to chat-panel-only changes.

### Chat panel
- New `ChatPanel` (320px) mounted as a flex sibling of `<main>` and `GhostPanel` — both right-side panels can be open at the same time without overlap.
- Per-project chat history (`Project.chatMessages`), capped at 20 messages with FIFO eviction so token cost stays bounded.
- **Canvas context toggle** (default on): when enabled, the user's current notes are summarised into the system prompt so the assistant can reference them, surface contradictions, and suggest connections. Closes the loop between annotation and discovery.
- **Capture flow** per assistant message: click "Capture" → text becomes editable in an inline textarea → trim → "Add to canvas" pipes the result through the existing `addBlock`, which runs normal enrichment. Any captured note can be re-enriched again later via the new tile button.
- **Web grounding** is automatic: the chat reuses `loadAIConfig()` and inherits whichever `groundingMode` is active (`exa`, `native`, or `off`). Exa search failures degrade gracefully without blocking replies.
- Status bar toggle button next to the Synthesis toggle, badge with unread count.
- `open-chat` command in the vim / Cmd-K palette.
- Esc closes the chat panel before the synthesis panel if both are open.

### Re-enrich button + undo
- Visible `RefreshCw` button in every tile-card action row (non-thesis tiles — thesis already has its own).
- `reEnrichBlock` in `app/page.tsx` now snapshots history via `pushHistory` itself, so **every caller** (the new button, the type changer, the thesis refresh, the chat capture flow) gets undo for free. Cmd+Z restores the previous annotation, category, and contentType in one shot.

### Files

- New: `components/chat-panel.tsx`, `lib/ai-chat.ts`
- Modified: `app/page.tsx`, `components/status-bar.tsx`, `components/tile-card.tsx`, `components/vim-input.tsx`

## Test plan

- [ ] `pnpm dev`
- [ ] Click the new MessageSquare icon in the status bar (or Cmd+K → "Chat") — chat panel slides in from the right
- [ ] With the synthesis panel also open, both panels stack on the right and the canvas reflows correctly
- [ ] Type a question and hit Enter → spinner → assistant reply renders with markdown
- [ ] Toggle "Include canvas context" off → next reply should ignore canvas notes
- [ ] On an assistant reply, click "Capture" → trim the text → "Add to canvas" creates a new note that auto-enriches
- [ ] Add a note, wait for enrichment, click the new RefreshCw button → annotation regenerates → Cmd+Z restores the previous version
- [ ] Set up Exa key from #24 → chat replies should pull live web sources and show source tiles below the message
- [ ] Without an API key, chat input is disabled with an inline hint
- [ ] Esc closes the chat panel; pressing Esc again closes synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)