### PR TITLE
Add Docker support — multi-stage Dockerfile and compose config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# Node / build artifacts
+node_modules
+.next
+out
+dist
+tsconfig.tsbuildinfo
+next-env.d.ts
+
+# Env
+.env*.local
+.env
+
+# Editor / OS
+.DS_Store
+.vscode
+.idea
+
+# Claude / internal
+.claude
+CLAUDE.md
+
+# v0 runtime files
+__v0_runtime_loader.js
+__v0_devtools.tsx
+__v0_jsx-dev-runtime.ts
+
+# Local-only design system
+app/design-system
+
+# Docker / docs (not needed in image)
+Dockerfile
+.dockerignore
+docker-compose.yml
+docker-compose.yaml
+README.md
+LICENSE

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# nodepad has no server-side secrets — AI provider keys are entered in the
+# browser and stored in localStorage. These variables only control the
+# container runtime.
+
+# Host port to expose. The container always listens on 3000 internally;
+# this only changes the port on your machine.
+HOST_PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.7
+
+# ── deps ──────────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS deps
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ── builder ───────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+# ── runner ────────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# node:alpine ships a `node` user (uid 1000); run as non-root.
+USER node
+
+# Next standalone output emits a minimal server bundle, but `public/` and
+# `.next/static` must be copied explicitly — they are not bundled.
+COPY --chown=node:node --from=builder /app/public ./public
+COPY --chown=node:node --from=builder /app/.next/standalone ./
+COPY --chown=node:node --from=builder /app/.next/static ./.next/static
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ npm run dev
 
 Open [localhost:3000](http://localhost:3000).
 
+### Run with Docker
+
+Requires Docker and Docker Compose.
+
+```bash
+git clone https://github.com/mskayyali/nodepad.git
+cd nodepad
+docker compose up --build
+```
+
+Open [localhost:3000](http://localhost:3000). To run in the background use `docker compose up -d`, and `docker compose down` to stop.
+
+The container is stateless — notes and API keys live in your browser's `localStorage`, so there is nothing to mount or back up server-side. Override the host port with `HOST_PORT=8080 docker compose up` (see `.env.example`).
+
+Do not scale the `web` service beyond one replica: `/api/fetch-url` uses an in-process rate limiter that assumes a single instance.
+
 **Add your API key**: click the menu icon (top-left) → Settings → choose your provider → paste your key. The key is stored in your browser's `localStorage` and goes directly to the AI provider — it never passes through any server.
 
 **Enable web grounding** (optional): toggle "Web grounding" in Settings to let the AI cite real sources for claims, questions, and references. Supported on OpenRouter `:online` models and OpenAI search-preview models.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+# nodepad — single-container compose file.
+#
+# The app is stateless: all notes and AI keys live in the browser's
+# localStorage, so there is nothing to mount and nothing to back up server-side.
+#
+# Do NOT scale this service beyond 1 replica — proxy.ts uses an in-memory
+# rate limiter for /api/fetch-url that assumes a single process.
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: nodepad:latest
+    restart: unless-stopped
+    init: true
+    ports:
+      - "${HOST_PORT:-3000}:3000"
+    environment:
+      NODE_ENV: production
+      NEXT_TELEMETRY_DISABLED: "1"
+      HOSTNAME: 0.0.0.0
+      PORT: "3000"
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://localhost:3000').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Emit a self-contained server bundle for container deployments.
+  // Ignored by Vercel, which uses its own build adapter.
+  output: "standalone",
   typescript: {
     // Build errors are intentionally ignored — see CLAUDE.md
     ignoreBuildErrors: true,


### PR DESCRIPTION
## Summary

Lets self-hosters run nodepad with a single `docker compose up` — no local Node toolchain needed. The container is stateless (notes and AI keys live in the browser's `localStorage`), so there's nothing to mount, back up, or configure on the server side.

- **Multi-stage Dockerfile** (`deps` → `builder` → `runner`) on `node:22-alpine`, non-root `node` user, ~313 MB image
- **`output: "standalone"`** in `next.config.mjs` for a minimal self-contained server bundle. This is ignored by Vercel's build adapter, so the existing Vercel deployment path is unaffected
- **`docker-compose.yml`** with `init: true` (tini as PID 1 for correct signal handling) and a `node -e 'fetch(...)'` healthcheck so the image doesn't need curl/wget
- **`HOST_PORT`** env var to override the host-side port mapping; the container always binds to `3000` internally. `.env.example` documents it
- **`.dockerignore`** mirroring `.gitignore` plus build artifacts and local-only files
- **README**: new "Run with Docker" subsection under Setup, with an explicit note about the single-replica constraint (see below)

## Notes for reviewers

- **Do not scale `web` beyond 1 replica.** `proxy.ts` uses an in-memory `Map` as a rate limiter for `/api/fetch-url`, which assumes a single process. This is called out in both the compose file header and the README.
- **No server-side secrets.** The only env vars in `.env.example` control the container runtime (`HOST_PORT`). AI provider keys continue to live in `localStorage` and go directly to the provider.
- **Standalone mode footgun handled:** Next's `output: "standalone"` does not auto-copy `public/` or `.next/static`; the runner stage copies them explicitly.

## Test plan

- [x] `docker compose build` succeeds on `node:22-alpine`
- [x] `docker compose up -d` — container starts and healthcheck transitions to `healthy`
- [x] `GET /` → 200, HTML served
- [x] `GET /icon.svg` → 200 (confirms `public/` was copied in standalone mode)
- [x] `cat /proc/1/comm` inside container → `docker-init` (tini is PID 1, signal forwarding works)
- [x] `docker compose down` — clean shutdown
- [x] Reviewer smoke-test: add a note in the browser end-to-end (requires an AI provider key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)