### PR TITLE
feat: add native Anthropic provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ GLM models from Zhipu AI. Get a key at [z.ai](https://z.ai/manage-apikey/apikey-
 | `glm-5` | Z.ai flagship model. |
 | `glm-5-turbo` | Fast, community-tested. |
 
+### Anthropic *(direct)*
+Use your Anthropic API key directly against the native Messages API. Get a key at [console.anthropic.com](https://console.anthropic.com/settings/keys). Structured output is enforced via forced tool use, so schema fidelity is as strong as OpenAI's `json_schema` mode. Web grounding is not supported on this path.
+
+| Model | Notes |
+|---|---|
+| `claude-opus-4-7` | Frontier reasoning & agentic coding, 1M context. |
+| `claude-sonnet-4-6` | Best balance of speed and intelligence, 1M context. |
+| `claude-opus-4-6` | Prior Opus generation, 1M context. |
+| `claude-sonnet-4-5` | Prior Sonnet generation, 200K context. |
+| `claude-opus-4-5` | Prior Opus generation, 200K context. |
+| `claude-haiku-4-5` | Fastest, near-frontier quality, 200K context. |
+
 ---
 
 ## Keyboard shortcuts

--- a/lib/ai-enrich.ts
+++ b/lib/ai-enrich.ts
@@ -279,7 +279,13 @@ export async function enrichBlockClient(
     }
   }
 
-  const supportsJsonSchema = config.provider === "openrouter" || config.provider === "openai"
+  // Native Anthropic enforces structure via forced tool_use (see the call path
+  // below) — treat it as strict-schema capable so we don't inject the fallback
+  // schemaHint into the system prompt (tool_use already constrains the shape).
+  const supportsJsonSchema =
+    config.provider === "openrouter" ||
+    config.provider === "openai" ||
+    config.provider === "anthropic"
   // gpt-*-search-preview models have known issues with strict json_schema + web_search_options;
   // fall back to json_object mode (guaranteed valid JSON, no schema enforcement)
   const useStrictSchema = supportsJsonSchema && !webSearchOptions
@@ -347,6 +353,75 @@ You have live web access. For this note type, include 1–2 real source citation
   const MAX_ENRICH_OUTPUT_TOKENS = 1200
 
   const baseUrl = getBaseUrl(config)
+
+  // ── Native Anthropic path ───────────────────────────────────────────────
+  // Uses the Messages API with forced tool_use for structured output. Forced
+  // tool_choice is incompatible with extended/adaptive thinking, so we never
+  // send a `thinking` field — thinking defaults to off on all Claude 4.x
+  // models we expose (Opus 4.5/4.6/4.7, Sonnet 4.5/4.6, Haiku 4.5), so this
+  // gives us deterministic, low-latency enrichment that matches the schema.
+  if (config.provider === "anthropic") {
+    const response = await fetch(`${baseUrl}/messages`, {
+      method: "POST",
+      headers: getProviderHeaders(config),
+      body: JSON.stringify({
+        model,
+        max_tokens: MAX_ENRICH_OUTPUT_TOKENS,
+        // Anthropic puts system instructions in a top-level field, not in `messages`.
+        system: systemPrompt,
+        messages: [
+          { role: "user", content: userMessage },
+        ],
+        temperature: 0.1,
+        // Force the model to produce a single structured call to our synthetic
+        // tool — its `input` object will conform to JSON_SCHEMA.schema.
+        tools: [
+          {
+            name: JSON_SCHEMA.name,
+            description: "Emit the enrichment result for the note.",
+            input_schema: JSON_SCHEMA.schema,
+          },
+        ],
+        tool_choice: {
+          type: "tool",
+          name: JSON_SCHEMA.name,
+          disable_parallel_tool_use: true,
+        },
+      }),
+    })
+
+    if (!response.ok) {
+      throw new Error(await parseProviderError(response))
+    }
+
+    let data: {
+      content?: Array<{ type: string; input?: unknown; text?: string }>
+      stop_reason?: string
+    }
+    try {
+      data = await response.json()
+    } catch {
+      throw new Error(
+        `AI enrich error (anthropic): response was not valid JSON. The provider may have timed out or returned a truncated response.`
+      )
+    }
+
+    const toolUse = data.content?.find(b => b.type === "tool_use")
+    if (!toolUse || !toolUse.input || typeof toolUse.input !== "object") {
+      const preview = JSON.stringify(data).slice(0, 300)
+      throw new Error(
+        `Anthropic did not return a tool_use block.${data.stop_reason ? ` stop_reason: ${data.stop_reason}.` : ""} Raw: ${preview}`
+      )
+    }
+
+    const result = toolUse.input as EnrichResult
+    if (result.confidence != null) {
+      result.confidence = Math.min(100, Math.max(0, Math.round(result.confidence)))
+    }
+    return result
+  }
+
+  // ── OpenAI-compatible path (openrouter / openai / zai) ──────────────────
   const response = await fetch(`${baseUrl}/chat/completions`, {
     method: "POST",
     headers: getProviderHeaders(config),

--- a/lib/ai-ghost.ts
+++ b/lib/ai-ghost.ts
@@ -56,6 +56,70 @@ Return ONLY valid JSON:
   const MAX_GHOST_OUTPUT_TOKENS = 220
 
   const baseUrl = getBaseUrl(config)
+
+  // ── Native Anthropic path ───────────────────────────────────────────────
+  // Same forced-tool_use trick as ai-enrich.ts — guarantees valid JSON matching
+  // the {text, category} shape without any fragile regex fallback.
+  if (config.provider === "anthropic") {
+    const GHOST_TOOL = {
+      name: "emergent_thesis",
+      description: "Emit the emergent thesis for the canvas.",
+      input_schema: {
+        type: "object",
+        properties: {
+          text:     { type: "string", description: "A 15–25 word bridge thesis or question" },
+          category: { type: "string", description: "One-word category naming the bridge topic" },
+        },
+        required: ["text", "category"],
+        additionalProperties: false,
+      },
+    }
+
+    const response = await fetch(`${baseUrl}/messages`, {
+      method: "POST",
+      headers: getProviderHeaders(config),
+      body: JSON.stringify({
+        model,
+        max_tokens: MAX_GHOST_OUTPUT_TOKENS,
+        // Ghost has no separate system prompt — the whole thing is the user turn.
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.7,
+        tools: [GHOST_TOOL],
+        tool_choice: {
+          type: "tool",
+          name: GHOST_TOOL.name,
+          disable_parallel_tool_use: true,
+        },
+      }),
+    })
+
+    if (!response.ok) {
+      throw new Error(await parseProviderError(response))
+    }
+
+    let data: {
+      content?: Array<{ type: string; input?: unknown; text?: string }>
+      stop_reason?: string
+    }
+    try {
+      data = await response.json()
+    } catch {
+      throw new Error(
+        `AI ghost error (anthropic): response was not valid JSON. The provider may have timed out or returned a truncated response.`
+      )
+    }
+
+    const toolUse = data.content?.find(b => b.type === "tool_use")
+    if (!toolUse || !toolUse.input || typeof toolUse.input !== "object") {
+      const preview = JSON.stringify(data).slice(0, 300)
+      throw new Error(
+        `Anthropic did not return a tool_use block.${data.stop_reason ? ` stop_reason: ${data.stop_reason}.` : ""} Raw: ${preview}`
+      )
+    }
+    return toolUse.input as GhostResult
+  }
+
+  // ── OpenAI-compatible path (openrouter / openai / zai) ──────────────────
   const response = await fetch(`${baseUrl}/chat/completions`, {
     method: "POST",
     headers: getProviderHeaders(config),

--- a/lib/ai-settings.ts
+++ b/lib/ai-settings.ts
@@ -12,7 +12,7 @@ export interface AIModel {
   groundingModelId?: string
 }
 
-export type AIProvider = "openrouter" | "openai" | "zai"
+export type AIProvider = "openrouter" | "openai" | "zai" | "anthropic"
 
 export interface AIProviderPreset {
   id: AIProvider
@@ -43,6 +43,16 @@ export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
     baseUrl: "https://api.z.ai/api/paas/v4",
     keyUrl: "https://z.ai/manage-apikey/apikey-list",
     keyPlaceholder: "Your Z.ai API key",
+  },
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    // Native Messages API — request URLs are built as `${baseUrl}/messages`
+    // in call sites that branch on provider === "anthropic" (see ai-enrich.ts,
+    // ai-ghost.ts). Other providers append `/chat/completions` to their baseUrl.
+    baseUrl: "https://api.anthropic.com/v1",
+    keyUrl: "https://console.anthropic.com/settings/keys",
+    keyPlaceholder: "sk-ant-...",
   },
 ]
 
@@ -143,6 +153,59 @@ export const OPENAI_MODELS: AIModel[] = [
   },
 ]
 
+// Native Anthropic models — accessed via the Messages API with forced tool_use
+// for structured output (see ai-enrich.ts and ai-ghost.ts). Web grounding is
+// intentionally not exposed: Anthropic supports a server-side web_search tool
+// but wiring it up is a separate feature.
+//
+// Tool use is incompatible with extended/adaptive thinking when tool_choice is
+// forced to a specific tool — so nodepad's Anthropic path never sends the
+// `thinking` field. Thinking defaults to off on all listed models.
+export const ANTHROPIC_MODELS: AIModel[] = [
+  {
+    id: "claude-opus-4-7",
+    label: "Claude Opus 4.7",
+    shortLabel: "Opus 4.7",
+    description: "Frontier reasoning & agentic coding, 1M context",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-sonnet-4-6",
+    label: "Claude Sonnet 4.6",
+    shortLabel: "Sonnet 4.6",
+    description: "Best balance of speed and intelligence, 1M context",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-opus-4-6",
+    label: "Claude Opus 4.6",
+    shortLabel: "Opus 4.6",
+    description: "Prior Opus generation, 1M context",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-sonnet-4-5",
+    label: "Claude Sonnet 4.5",
+    shortLabel: "Sonnet 4.5",
+    description: "Prior Sonnet generation, 200K context",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-opus-4-5",
+    label: "Claude Opus 4.5",
+    shortLabel: "Opus 4.5",
+    description: "Prior Opus generation, 200K context",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-haiku-4-5",
+    label: "Claude Haiku 4.5",
+    shortLabel: "Haiku 4.5",
+    description: "Fastest, near-frontier quality, 200K context",
+    supportsGrounding: false,
+  },
+]
+
 export const ZAI_MODELS: AIModel[] = [
   {
     id: "glm-4.5",
@@ -175,8 +238,9 @@ export const ZAI_MODELS: AIModel[] = [
 ]
 
 export function getModelsForProvider(provider: AIProvider): AIModel[] {
-  if (provider === "openai") return OPENAI_MODELS
-  if (provider === "zai")    return ZAI_MODELS
+  if (provider === "openai")    return OPENAI_MODELS
+  if (provider === "zai")       return ZAI_MODELS
+  if (provider === "anthropic") return ANTHROPIC_MODELS
   return AI_MODELS // openrouter + safe fallback for any stale localStorage value
 }
 
@@ -240,6 +304,19 @@ export function getBaseUrl(config: AIConfig): string {
 }
 
 export function getProviderHeaders(config: AIConfig): Record<string, string> {
+  // Anthropic uses a different auth scheme (x-api-key, not Bearer) and
+  // requires an explicit opt-in header for direct browser access, since
+  // nodepad calls the Messages API from localStorage-stored keys with no
+  // backend proxy in between.
+  if (config.provider === "anthropic") {
+    return {
+      "Content-Type": "application/json",
+      "x-api-key": config.apiKey,
+      "anthropic-version": "2023-06-01",
+      "anthropic-dangerous-direct-browser-access": "true",
+    }
+  }
+
   const base: Record<string, string> = {
     "Content-Type": "application/json",
     "Authorization": `Bearer ${config.apiKey}`,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -47,7 +47,7 @@ const nextConfig = {
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cloud.umami.is",
               "style-src 'self' 'unsafe-inline'",
-              "connect-src 'self' https://openrouter.ai https://api.openai.com https://api.z.ai https://cloud.umami.is https://api-gateway.umami.dev",
+              "connect-src 'self' https://openrouter.ai https://api.openai.com https://api.z.ai https://api.anthropic.com https://cloud.umami.is https://api-gateway.umami.dev",
               "img-src 'self' data: blob: https://i.ytimg.com",
               "font-src 'self' data:",
               "frame-src https://www.youtube-nocookie.com https://www.youtube.com",


### PR DESCRIPTION
## Summary

Adds Anthropic as a first-class provider alongside OpenRouter, OpenAI, and Z.ai. Users can bring an `sk-ant-...` key directly and talk to the Messages API from the browser — no OpenRouter account, no local proxy.

## How it works

- New `"anthropic"` entry in `AI_PROVIDER_PRESETS`; the sidebar settings UI picks it up automatically (no UI code changes needed — the existing map over `AI_PROVIDER_PRESETS` handles it, and the grounding toggle is already scoped to openrouter/openai only).
- `getProviderHeaders` branches to emit `x-api-key` + `anthropic-version: 2023-06-01` + `anthropic-dangerous-direct-browser-access: true` instead of `Authorization: Bearer`.
- `ai-enrich.ts` and `ai-ghost.ts` branch on `provider === "anthropic"` at the HTTP-call boundary:
  - POST to `{baseUrl}/messages` instead of `/chat/completions`
  - System prompt moved to top-level `system` field (Anthropic's Messages API shape)
  - **Structured output via forced `tool_use`** — a synthetic tool (`enrichment_result` / `emergent_thesis`) is defined with `input_schema` and forced via `tool_choice: {type: "tool", name: "...", disable_parallel_tool_use: true}`. Schema fidelity is equivalent to OpenAI's strict `json_schema` mode; no regex fallback needed.
  - Response parsing reads `content[].type === "tool_use"` and uses `.input` directly.
- CSP `connect-src` in `next.config.mjs` gains `https://api.anthropic.com` (without this, Firefox silently shows `NetworkError when attempting to fetch resource`; Chrome says "Refused to connect... violates CSP").
- README gets an "Anthropic *(direct)*" subsection mirroring the existing provider entries.

## Design notes

**Why no `thinking` field is sent, even on 4.7**: forced `tool_choice: {type: "tool"}` is [explicitly incompatible](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-thinking-with-tool-use) with extended/adaptive thinking — the API rejects the combination with a 400. Thinking defaults to off on all exposed models (Opus 4.5/4.6/4.7, Sonnet 4.5/4.6, Haiku 4.5), so omitting the field is correct, forward-compatible, and gives deterministic low-latency enrichment that matches the schema every time. Task-fit also supports this: classification, connection inference, and short annotations don't meaningfully benefit from deep reasoning, and enrichment is the user-facing latency path.

Ghost synthesis *could* plausibly benefit from adaptive thinking, but that would require dropping forced tool_choice to `auto` and handling two response shapes (tool_use + text fallback). That's a cleaner follow-up PR than bundling with provider addition.

**Web grounding** is intentionally not wired up on the Anthropic path. Anthropic has a server-side web-search tool but it's a separate feature; `supportsGrounding: false` on all Claude models cleanly hides the grounding UI (same pattern as the Z.ai provider).

## Files changed

| File | Purpose |
|---|---|
| `lib/ai-settings.ts` | Add `"anthropic"` to provider union, preset, `ANTHROPIC_MODELS`, header branch |
| `lib/ai-enrich.ts` | Messages API + forced tool_use branch |
| `lib/ai-ghost.ts` | Same pattern for synthesis |
| `next.config.mjs` | CSP `connect-src` allowlist |
| `README.md` | "Anthropic *(direct)*" subsection |

## Testing

- `npx tsc --noEmit` — clean
- `npm run build` — passes (2.3s compile, all pages generated)
- Live test against `claude-sonnet-4-6` and `claude-opus-4-7`: enrichment produces valid classifications, annotations, and `influencedByIndices`; ghost synthesis fires correctly after accumulating notes across categories
- Existing OpenRouter, OpenAI, and Z.ai code paths unaffected (branches occur before divergent logic)