### PR TITLE
feat(workspaces): added move/copy node between spaces

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -757,6 +757,67 @@ export default function Page() {
     })
   }, [activeProjectId])
 
+  // Move a block from the active workspace to another workspace.
+  // Connections (influencedBy) reference IDs in the source workspace and
+  // would be dangling in the target, so we drop them — the block can be
+  // re-enriched in its new context to discover new connections.
+  const moveBlockToWorkspace = useCallback((blockId: string, targetWorkspaceId: string) => {
+    if (targetWorkspaceId === activeProjectId) return
+    pushHistory(activeProjectId, blocksRef.current)
+    setProjects(prev => {
+      const source = prev.find(p => p.id === activeProjectId)
+      const block = source?.blocks.find(b => b.id === blockId)
+      if (!block) return prev
+      return prev.map(p => {
+        if (p.id === activeProjectId) {
+          return {
+            ...p,
+            blocks: p.blocks.filter(b => b.id !== blockId),
+            collapsedIds: p.collapsedIds.filter(id => id !== blockId),
+          }
+        }
+        if (p.id === targetWorkspaceId) {
+          const idCollision = p.blocks.some(b => b.id === blockId)
+          const moved: TextBlock = {
+            ...block,
+            id: idCollision ? generateId() : block.id,
+            influencedBy: undefined,
+          }
+          return { ...p, blocks: [...p.blocks, moved] }
+        }
+        return p
+      })
+    })
+    showUndoToast(`→ Moved to ${projectsRef.current.find(p => p.id === targetWorkspaceId)?.name ?? "space"}`)
+  }, [activeProjectId, pushHistory, showUndoToast])
+
+  // Copy keeps the original in place and creates a fresh node (new id, new
+  // timestamp, no inherited connections) in the target workspace.
+  const copyBlockToWorkspace = useCallback((blockId: string, targetWorkspaceId: string) => {
+    if (targetWorkspaceId === activeProjectId) return
+    setProjects(prev => {
+      const source = prev.find(p => p.id === activeProjectId)
+      const block = source?.blocks.find(b => b.id === blockId)
+      if (!block) return prev
+      return prev.map(p => {
+        if (p.id !== targetWorkspaceId) return p
+        const copy: TextBlock = {
+          ...block,
+          id: generateId(),
+          timestamp: Date.now(),
+          influencedBy: undefined,
+        }
+        return { ...p, blocks: [...p.blocks, copy] }
+      })
+    })
+    showUndoToast(`⎘ Copied to ${projectsRef.current.find(p => p.id === targetWorkspaceId)?.name ?? "space"}`)
+  }, [activeProjectId, showUndoToast])
+
+  const workspaceOptions = useMemo(
+    () => projects.map(p => ({ id: p.id, name: p.name })),
+    [projects]
+  )
+
   const handleCommand = useCallback((cmd: string, text?: string) => {
     setIsCommandKOpen(false)
     
@@ -915,6 +976,10 @@ export default function Page() {
                   onDeleteSubTask={handleDeleteSubTask}
                   highlightedBlockId={highlightedBlockId}
                   onHighlight={setHighlightedBlockId}
+                  workspaces={workspaceOptions}
+                  activeWorkspaceId={activeProjectId}
+                  onMoveToWorkspace={moveBlockToWorkspace}
+                  onCopyToWorkspace={copyBlockToWorkspace}
                 />
               ) : viewMode === "kanban" ? (
                 <KanbanArea
@@ -930,6 +995,10 @@ export default function Page() {
                   onToggleSubTask={handleToggleSubTask}
                   onDeleteSubTask={handleDeleteSubTask}
                   collapsedIds={new Set(activeProject.collapsedIds)}
+                  workspaces={workspaceOptions}
+                  activeWorkspaceId={activeProjectId}
+                  onMoveToWorkspace={moveBlockToWorkspace}
+                  onCopyToWorkspace={copyBlockToWorkspace}
                 />
               ) : (
                 <GraphArea

--- a/components/kanban-area.tsx
+++ b/components/kanban-area.tsx
@@ -20,6 +20,10 @@ interface KanbanAreaProps {
   onToggleSubTask: (id: string, subTaskId: string) => void
   onDeleteSubTask: (id: string, subTaskId: string) => void
   collapsedIds: Set<string>
+  workspaces?: { id: string; name: string }[]
+  activeWorkspaceId?: string
+  onMoveToWorkspace?: (blockId: string, targetWorkspaceId: string) => void
+  onCopyToWorkspace?: (blockId: string, targetWorkspaceId: string) => void
 }
 
 export function KanbanArea({
@@ -34,6 +38,10 @@ export function KanbanArea({
   onToggleSubTask,
   onDeleteSubTask,
   collapsedIds,
+  workspaces,
+  activeWorkspaceId,
+  onMoveToWorkspace,
+  onCopyToWorkspace,
 }: KanbanAreaProps) {
   const mod = useModKey()
   const [hoveredConnectionId, setHoveredConnectionId] = useState<string | null>(null)
@@ -162,6 +170,10 @@ export function KanbanArea({
                         onConnectionLock={handleConnectionLock}
                         isConnectionLocked={lockedConnectionId === block.id}
                         allBlocks={blocks}
+                        workspaces={workspaces}
+                        activeWorkspaceId={activeWorkspaceId}
+                        onMoveToWorkspace={onMoveToWorkspace}
+                        onCopyToWorkspace={onCopyToWorkspace}
                       />
                     </div>
                   )

--- a/components/tile-card.tsx
+++ b/components/tile-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo, memo } from "react"
 import { createPortal } from "react-dom"
-import { X, Check, Pin, RefreshCw, ChevronDown, ChevronRight, ChevronLeft, Link as LinkIcon, Sparkles, Tag } from "lucide-react"
+import { X, Check, Pin, RefreshCw, ChevronDown, ChevronRight, ChevronLeft, Link as LinkIcon, Sparkles, Tag, FolderInput, ArrowRightFromLine, Copy } from "lucide-react"
 import { motion } from "framer-motion"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
@@ -45,6 +45,11 @@ interface TileCardProps {
   isConnectionLocked?: boolean
   allBlocks?: TextBlock[]
   onChangeType?: (id: string, newType: ContentType) => void
+  // Move/copy to other workspaces
+  workspaces?: { id: string; name: string }[]
+  activeWorkspaceId?: string
+  onMoveToWorkspace?: (blockId: string, targetWorkspaceId: string) => void
+  onCopyToWorkspace?: (blockId: string, targetWorkspaceId: string) => void
 }
 
 // Custom Markdown components for styling
@@ -101,6 +106,10 @@ export const TileCard = memo(function TileCard({
   allBlocks,
   hideCollapse = false,
   onChangeType,
+  workspaces,
+  activeWorkspaceId,
+  onMoveToWorkspace,
+  onCopyToWorkspace,
 }: TileCardProps) {
   // In tiling view, collapse is disabled — BSP layout can't redistribute freed space
   const effectiveCollapsed = hideCollapse ? false : isCollapsed
@@ -116,6 +125,10 @@ export const TileCard = memo(function TileCard({
   const [pickerRect, setPickerRect] = useState<DOMRect | null>(null)
   const typeChangeButtonRef = useRef<HTMLButtonElement>(null)
   const typePickerDropdownRef = useRef<HTMLDivElement>(null)
+  const [isMoveMenuOpen, setIsMoveMenuOpen] = useState(false)
+  const [moveMenuRect, setMoveMenuRect] = useState<DOMRect | null>(null)
+  const moveMenuButtonRef = useRef<HTMLButtonElement>(null)
+  const moveMenuDropdownRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const annotationRef = useRef<HTMLTextAreaElement>(null)
   const footerRef = useRef<HTMLDivElement>(null)
@@ -182,6 +195,27 @@ export const TileCard = memo(function TileCard({
       document.removeEventListener("mousedown", handleMouseDown)
     }
   }, [isTypePickerOpen])
+
+  // Same outside-click / Escape behavior for the move-to-workspace dropdown
+  useEffect(() => {
+    if (!isMoveMenuOpen) return
+    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") setIsMoveMenuOpen(false) }
+    const handleMouseDown = (e: MouseEvent) => {
+      const t = e.target as Node
+      if (
+        !moveMenuButtonRef.current?.contains(t) &&
+        !moveMenuDropdownRef.current?.contains(t)
+      ) {
+        setIsMoveMenuOpen(false)
+      }
+    }
+    window.addEventListener("keydown", handleKey)
+    document.addEventListener("mousedown", handleMouseDown)
+    return () => {
+      window.removeEventListener("keydown", handleKey)
+      document.removeEventListener("mousedown", handleMouseDown)
+    }
+  }, [isMoveMenuOpen])
 
   const handleSave = useCallback(() => {
     if (editText.trim() && editText !== block.text) {
@@ -402,6 +436,24 @@ export const TileCard = memo(function TileCard({
               <Pin className={`h-2.5 w-2.5 transition-transform ${block.isPinned ? "fill-current" : "-rotate-45"}`} />
             </button>
           )}
+          {/* Move/Copy to another workspace — portal dropdown */}
+          {onMoveToWorkspace && onCopyToWorkspace && workspaces && workspaces.length > 1 && !effectiveCollapsed && (
+            <button
+              ref={moveMenuButtonRef}
+              onClick={e => {
+                e.stopPropagation()
+                if (moveMenuButtonRef.current) {
+                  setMoveMenuRect(moveMenuButtonRef.current.getBoundingClientRect())
+                }
+                setIsMoveMenuOpen(v => !v)
+              }}
+              className={`flex h-4 w-4 items-center justify-center rounded-sm transition-all ${isMoveMenuOpen ? "bg-black/20 opacity-100" : "opacity-40 hover:opacity-100 hover:bg-black/10"}`}
+              title="Move or copy to another space"
+              aria-label="Move or copy to another space"
+            >
+              <FolderInput className="h-2.5 w-2.5" />
+            </button>
+          )}
           {/* Change-type button — portal dropdown, clear of tile overflow:hidden */}
           {onChangeType && !effectiveCollapsed && (
             <button
@@ -474,6 +526,61 @@ export const TileCard = memo(function TileCard({
                   </button>
                 )
               })}
+          </div>
+        </div>,
+        document.body
+      )}
+
+      {/* Move/Copy menu — rendered via portal so it escapes tile overflow:hidden */}
+      {isMoveMenuOpen && moveMenuRect && workspaces && onMoveToWorkspace && onCopyToWorkspace && isMounted && createPortal(
+        <div
+          ref={moveMenuDropdownRef}
+          className="rounded-md border border-border bg-card shadow-xl"
+          style={{
+            position: "fixed",
+            top: moveMenuRect.bottom + 4,
+            right: window.innerWidth - moveMenuRect.right,
+            minWidth: 240,
+            maxWidth: 320,
+            zIndex: 9999,
+          }}
+          onMouseDown={e => e.stopPropagation()}
+        >
+          <p className="px-2.5 pt-2 pb-1 font-mono text-[9px] uppercase tracking-widest text-muted-foreground/50">
+            Move or copy to space
+          </p>
+          <div className="flex flex-col gap-px p-1.5 pt-0 max-h-[280px] overflow-y-auto custom-scrollbar">
+            {workspaces.filter(w => w.id !== activeWorkspaceId).map(w => (
+              <div
+                key={w.id}
+                className="group/row flex items-center gap-1 rounded-sm px-2 py-1 hover:bg-secondary/40"
+              >
+                <span className="flex-1 truncate font-mono text-[11px] font-bold text-foreground">
+                  {w.name}
+                </span>
+                <button
+                  onClick={() => { onMoveToWorkspace(block.id, w.id); setIsMoveMenuOpen(false) }}
+                  className="flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-muted-foreground hover:bg-primary/15 hover:text-primary transition-colors"
+                  title={`Move to ${w.name}`}
+                >
+                  <ArrowRightFromLine className="h-3 w-3" />
+                  <span className="font-mono text-[9px] uppercase tracking-wider">Move</span>
+                </button>
+                <button
+                  onClick={() => { onCopyToWorkspace(block.id, w.id); setIsMoveMenuOpen(false) }}
+                  className="flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-muted-foreground hover:bg-primary/15 hover:text-primary transition-colors"
+                  title={`Copy to ${w.name}`}
+                >
+                  <Copy className="h-3 w-3" />
+                  <span className="font-mono text-[9px] uppercase tracking-wider">Copy</span>
+                </button>
+              </div>
+            ))}
+            {workspaces.filter(w => w.id !== activeWorkspaceId).length === 0 && (
+              <p className="px-2 py-3 text-center font-mono text-[10px] text-muted-foreground/60">
+                No other spaces — create one first.
+              </p>
+            )}
           </div>
         </div>,
         document.body

--- a/components/tiling-area.tsx
+++ b/components/tiling-area.tsx
@@ -52,6 +52,10 @@ interface TilingAreaProps {
   onDeleteSubTask: (id: string, subTaskId: string) => void
   highlightedBlockId?: string | null
   onHighlight: (id: string | null) => void
+  workspaces?: { id: string; name: string }[]
+  activeWorkspaceId?: string
+  onMoveToWorkspace?: (blockId: string, targetWorkspaceId: string) => void
+  onCopyToWorkspace?: (blockId: string, targetWorkspaceId: string) => void
 }
 
 export function TilingArea({
@@ -68,6 +72,10 @@ export function TilingArea({
   onDeleteSubTask,
   highlightedBlockId,
   onHighlight,
+  workspaces,
+  activeWorkspaceId,
+  onMoveToWorkspace,
+  onCopyToWorkspace,
 }: TilingAreaProps) {
   const mod = useModKey()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -205,6 +213,10 @@ export function TilingArea({
               onConnectionLock={handleConnectionLock}
               isConnectionLocked={lockedConnectionId === block.id}
               allBlocks={blocks}
+              workspaces={workspaces}
+              activeWorkspaceId={activeWorkspaceId}
+              onMoveToWorkspace={onMoveToWorkspace}
+              onCopyToWorkspace={onCopyToWorkspace}
             />
           </div>
         </div>
@@ -252,6 +264,10 @@ export function TilingArea({
               onConnectionLock={handleConnectionLock}
               isConnectionLocked={lockedConnectionId === taskBlock.id}
               allBlocks={blocks}
+              workspaces={workspaces}
+              activeWorkspaceId={activeWorkspaceId}
+              onMoveToWorkspace={onMoveToWorkspace}
+              onCopyToWorkspace={onCopyToWorkspace}
             />
         </div>
       )}


### PR DESCRIPTION
Each tile now has a folder-input button in its header that opens a portal dropdown listing every other workspace, with Move and Copy actions per row. Move pushes an undo snapshot and removes the block from the source; Copy keeps the original and inserts a fresh node (new id, current timestamp) in the target. Both clear influencedBy since those references would dangle in the new workspace.

The button is hidden when only one workspace exists or when the tile is collapsed. Wired through TilingArea and KanbanArea; the graph view's detail panel is left untouched.