### PR TITLE
fix(tile-card): preserved edit buffer on double-click while editing

### DIFF
--- a/components/tile-card.tsx
+++ b/components/tile-card.tsx
@@ -229,6 +229,9 @@ export const TileCard = memo(function TileCard({
 
   const handleDoubleClick = useCallback((e: React.MouseEvent) => {
     if (effectiveCollapsed) return
+    // Already editing — let the native double-click select a word in the
+    // textarea instead of bubbling up and resetting our edit buffer.
+    if (isEditing || isEditingAnnotation) return
     const target = e.target as HTMLElement
     if (target.closest('a')) return
     // Capture current height before any state changes to prevent shrink during editing
@@ -240,7 +243,7 @@ export const TileCard = memo(function TileCard({
     }
     setEditText(block.text)
     setIsEditing(true)
-  }, [block.text, block.annotation, effectiveCollapsed])
+  }, [block.text, block.annotation, effectiveCollapsed, isEditing, isEditingAnnotation])
 
   const isTextRTL = useMemo(() => isRTL(block.text), [block.text])
   const isAnnotationRTL = useMemo(() => isRTL(block.annotation || ""), [block.annotation])


### PR DESCRIPTION
Double-clicking a tile to enter edit mode worked, but a second double-click (e.g. to select a word inside the textarea) bubbled up to the card's onDoubleClick and reset editText back to block.text, wiping the user's in-progress edits.

Bail out of handleDoubleClick early when already editing the body or annotation, so the native textarea behaviour (select word) takes over.