### PR TITLE
fix: Clamp confidence score range to 0-100 across the application

### DIFF
--- a/lib/ai-enrich.ts
+++ b/lib/ai-enrich.ts
@@ -97,6 +97,9 @@ The user message includes a [RESPOND IN: X] directive immediately before the not
 - **No URLs or hyperlinks ever.** If you reference a source, use its name and author only (e.g. "Per Kahneman's *Thinking, Fast and Slow*" or "IPCC AR6 report"). Never generate or guess a URL — broken links are worse than no links.
 - Use markdown sparingly: **bold** for key terms, *italic* for titles. No bullet lists in annotations.
 
+## Confidence Score
+Provide a single number between 0 and 100 representing your confidence in the classification and annotation quality for this note (100 = very confident).
+
 ## Classification Priority
 Use the most specific type. Avoid 'general' unless nothing else fits. 'thesis' is only valid if forcedType is set.
 
@@ -131,6 +134,7 @@ const JSON_SCHEMA = {
       annotation:         { type: "string" },
       confidence: {
         anyOf: [{ type: "number" }, { type: "null" }],
+        description: "Confidence score from 0 to 100 (integer or decimal).",
       },
       influencedByIndices: {
         type: "array",

--- a/lib/export.ts
+++ b/lib/export.ts
@@ -65,8 +65,9 @@ function formatTime(ts?: number): string {
 
 /** Five-block filled/empty bar + percentage */
 function confidenceBar(c: number): string {
-  const pct    = Math.round(c * 100)
-  const filled = Math.round(c * 5)
+  const clamped = Math.min(100, Math.max(0, c))
+  const pct     = Math.round(clamped)
+  const filled  = Math.round((clamped / 100) * 5)
   const bar    = "█".repeat(filled) + "░".repeat(5 - filled)
   return `${bar} ${pct}%`
 }


### PR DESCRIPTION
Confidence bars were always ~1% because the AI often returned a 0 - 1 score, but the UI treated it as 0 - 100 and rounded it to 1%. This PR standardizes confidence as 0-100 everywhere and aligns export formatting with that scale.

- The AI schema/prompt didn’t specify the confidence scale, so models returned a range in between (0,1).
- UI clamped/rounded the raw value as if it were already 0 to 100.
- Export formatting assumed (0,1) and multiplied by 100, creating an inconsistent pipeline.

Changes made:

- Json schema now explicitly specifies 0-100 confidence in the AI prompt
- In the clientside, clamp stays 0-100 (unchanged) which now matches the AI output.
- Export confidence bar now treats the value as 0-100 percentage.

| Before | After |
| ------- | -----  |
|<img width="521" height="175" alt="image" src="https://github.com/user-attachments/assets/d13a1305-484c-4b03-b7aa-c588f1489256" /> | <img width="509" height="175" alt="Control-V (2)" src="https://github.com/user-attachments/assets/e7c18ef9-d981-4ed8-a9cd-3c110a99b6f5" /> |


