### PR TITLE
fix: promote scroll containers to their own composite layers.

### DIFF
--- a/components/kanban-area.tsx
+++ b/components/kanban-area.tsx
@@ -121,6 +121,8 @@ export function KanbanArea({
       <div 
         ref={containerRef}
         className="flex h-full w-full overflow-x-auto custom-scrollbar p-6 pb-6 gap-8"
+        style={{ willChange: 'transform' }}
+
       >
         <AnimatePresence mode="popLayout">
           {columns.map(([key, col]) => (

--- a/components/tiling-area.tsx
+++ b/components/tiling-area.tsx
@@ -192,6 +192,8 @@ export function TilingArea({
           key={block.id}
           id={`tile-${block.id}`}
           className="flex flex-1 p-0.5 overflow-hidden"
+          style={{ willChange: 'transform' }}
+
         >
           <div className={`flex flex-1 min-w-0 transition-[opacity,filter] duration-300 ${isDimmed ? 'opacity-15 saturate-0' : 'opacity-100'}`}>
             <TileCard


### PR DESCRIPTION
This PR fixes #54 

I've applied `will-change: transform` to the scroll containers in `tiling-area.tsx` and `kanban-area.tsx` so it's explicitly instructing the browser to promote these elements to their own GPU compositor layers before interaction happens. This ensures scrolling runs entirely on the compositor thread and prevents expensive re-rasterization during UI navigation. And sure enough nodepad scrolls at 60 fps even on low end devices:

<img width="198" height="186" alt="image" src="https://github.com/user-attachments/assets/95d9f46e-4e94-4743-9820-3d2c29d4ea58" />

While this might not be very visible on systems made after 2020 or something it would however cause a decrease in cpu spike while using nodepad when scrolling with lots of nodes.

<img width="1308" height="805" alt="image" src="https://github.com/user-attachments/assets/0aab94f5-fe24-4bc3-a740-5994f20af867" />

_(As expected, barely any frames missing vsync deadlines)_