### PR TITLE
Closes #5 fix: show re-run enrichment button for all block types, not just thesis

### DIFF
--- a/components/tile-card.tsx
+++ b/components/tile-card.tsx
@@ -412,14 +412,14 @@ export const TileCard = memo(function TileCard({
           <span className="font-mono text-[10px] font-medium opacity-70">
             {formattedTime}
           </span>
-          {!effectiveCollapsed && block.contentType === "thesis" && (
+          {!effectiveCollapsed && (
             <button
               onClick={(e) => {
                 e.stopPropagation()
-                onReEnrich(block.id, "thesis")
+                onReEnrich(block.id, block.contentType === "thesis" ? "thesis" : undefined)
               }}
-              className="flex h-4 w-4 items-center justify-center rounded-sm transition-all hover:bg-black/20"
-              title="Refresh thesis synthesis"
+              className={`flex h-4 w-4 items-center justify-center rounded-sm transition-all hover:bg-black/20 ${block.contentType !== "thesis" ? "opacity-40 hover:opacity-100" : ""}`}
+              title="Re-run AI enrichment"
               disabled={block.isEnriching}
             >
               <RefreshCw className={`h-2.5 w-2.5 ${block.isEnriching ? "animate-spin opacity-50" : ""}`} />


### PR DESCRIPTION
Closes #5
Summary:
  - The "Re-run AI enrichment" button in the tile card header was previously only rendered for blocks with contentType === "thesis", leaving all other block types without a way to trigger re-enrichment.
  - The button is now shown for all block types. 
      - For thesis blocks, it still passes "thesis" as the enrichment type; for other blocks it passes undefined.
      - For Non-thesis blocks, i't shows the button at reduced opacity (dimmed) with full opacity on hover to subtly distinguish behavior.
  - Also Button tooltip has been updated from "Refresh thesis synthesis" to "Re-run AI enrichment" to reflect the broader scope.