### PR TITLE
feat: add Anthropic Claude as direct provider with full model lineup

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,59 +3,59 @@
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.dark *, .dark));
 
 :root {
-  --background: oklch(0.13 0.005 260);
-  --foreground: oklch(0.92 0 0);
-  --card: oklch(0.17 0.005 260);
-  --card-foreground: oklch(0.92 0 0);
-  --popover: oklch(0.17 0.005 260);
-  --popover-foreground: oklch(0.92 0 0);
-  --primary: oklch(0.72 0.19 155);
-  --primary-foreground: oklch(0.13 0.005 260);
-  --secondary: oklch(0.22 0.008 260);
-  --secondary-foreground: oklch(0.85 0 0);
-  --muted: oklch(0.22 0.008 260);
-  --muted-foreground: oklch(0.72 0 0);
-  --accent: oklch(0.72 0.19 155);
-  --accent-foreground: oklch(0.13 0.005 260);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
-  --border: oklch(0.28 0.01 260);
-  --input: oklch(0.22 0.008 260);
-  --ring: oklch(0.72 0.19 155);
-  --chart-1: oklch(0.72 0.19 155);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
+  --background: oklch(0.97 0.01 95);
+  --foreground: oklch(0.08 0 0);
+  --card: oklch(0.95 0.01 95);
+  --card-foreground: oklch(0.08 0 0);
+  --popover: oklch(0.97 0.01 95);
+  --popover-foreground: oklch(0.08 0 0);
+  --primary: oklch(0.5 0.18 155);
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.93 0.01 95);
+  --secondary-foreground: oklch(0.12 0 0);
+  --muted: oklch(0.93 0.01 95);
+  --muted-foreground: oklch(0.32 0 0);
+  --accent: oklch(0.5 0.18 155);
+  --accent-foreground: oklch(0.99 0 0);
+  --destructive: oklch(0.45 0.22 27);
+  --destructive-foreground: oklch(0.45 0.22 27);
+  --border: oklch(0.84 0.01 95);
+  --input: oklch(0.84 0.01 95);
+  --ring: oklch(0.5 0.18 155);
+  --chart-1: oklch(0.5 0.18 155);
+  --chart-2: oklch(0.55 0.16 185);
+  --chart-3: oklch(0.35 0.1 227);
+  --chart-4: oklch(0.75 0.2 84);
+  --chart-5: oklch(0.7 0.22 70);
   --radius: 0.25rem;
-  --sidebar: oklch(0.17 0.005 260);
-  --sidebar-foreground: oklch(0.92 0 0);
-  --sidebar-primary: oklch(0.72 0.19 155);
-  --sidebar-primary-foreground: oklch(0.13 0.005 260);
-  --sidebar-accent: oklch(0.22 0.008 260);
-  --sidebar-accent-foreground: oklch(0.85 0 0);
-  --sidebar-border: oklch(0.28 0.01 260);
-  --sidebar-ring: oklch(0.72 0.19 155);
-  --type-entity: oklch(0.65 0.12 250);
-  --type-claim: oklch(0.75 0.15 80);
-  --type-question: oklch(0.68 0.18 290);
-  --type-task: oklch(0.72 0.14 195);
-  --type-idea: oklch(0.72 0.22 340);
-  --type-reference: oklch(0.65 0.15 230);
-  --type-quote: oklch(0.72 0.19 155);
-  --type-definition: oklch(0.7 0.13 220);
-  --type-opinion: oklch(0.7 0.18 340);
-  --type-reflection: oklch(0.65 0.2 300);
-  --type-narrative: oklch(0.72 0.16 50);
-  --type-comparison: oklch(0.68 0.14 180);
-  --type-thesis: oklch(0.86 0.19 88); 
-  --type-general: oklch(0.55 0.02 260);
-  --thesis-gradient: linear-gradient(135deg, oklch(0.7 0.15 160), oklch(0.7 0.15 250));
-  --thesis-foreground: oklch(0.15 0.01 260);
-  --thesis-accent: oklch(0.7 0.15 200);
+  --sidebar: oklch(0.94 0.01 95);
+  --sidebar-foreground: oklch(0.08 0 0);
+  --sidebar-primary: oklch(0.5 0.18 155);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.93 0.01 95);
+  --sidebar-accent-foreground: oklch(0.12 0 0);
+  --sidebar-border: oklch(0.84 0.01 95);
+  --sidebar-ring: oklch(0.5 0.18 155);
+  --type-entity: oklch(0.45 0.24 250);
+  --type-claim: oklch(0.5 0.28 80);
+  --type-question: oklch(0.45 0.32 290);
+  --type-task: oklch(0.45 0.26 195);
+  --type-idea: oklch(0.45 0.35 340);
+  --type-reference: oklch(0.4 0.27 230);
+  --type-quote: oklch(0.45 0.3 155);
+  --type-definition: oklch(0.4 0.25 220);
+  --type-opinion: oklch(0.45 0.3 340);
+  --type-reflection: oklch(0.4 0.33 300);
+  --type-narrative: oklch(0.45 0.28 50);
+  --type-comparison: oklch(0.4 0.25 180);
+  --type-thesis: oklch(0.6 0.3 88);
+  --type-general: oklch(0.38 0.06 260);
+  --thesis-gradient: linear-gradient(135deg, oklch(0.54 0.2 160), oklch(0.5 0.2 250));
+  --thesis-foreground: oklch(0.08 0 0);
+  --thesis-accent: oklch(0.5 0.2 200);
 }
 
 .dark {
@@ -156,7 +156,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-semibold text-base;
   }
   /* Custom scrollbar for tile cards */
   ::-webkit-scrollbar {
@@ -198,11 +198,11 @@
 .shimmer-body {
   background: linear-gradient(
     90deg,
-    oklch(0.35 0 0) 0%,
-    oklch(0.35 0 0) 15%,
-    oklch(0.92 0 0) 50%,
-    oklch(0.35 0 0) 85%,
-    oklch(0.35 0 0) 100%
+    var(--muted) 0%,
+    var(--muted) 25%,
+    var(--foreground) 50%,
+    var(--muted) 75%,
+    var(--muted) 100%
   );
   background-size: 300% 100%;
   -webkit-background-clip: text;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono, Vazirmatn } from 'next/font/google'
 import Script from 'next/script'
+import { ThemeProvider } from 'next-themes'
 import { MobileWall } from '@/components/mobile-wall'
 import './globals.css'
 
@@ -40,10 +41,15 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: `(function(){try{var t=localStorage.getItem("theme");if(!t||t==="light"){document.documentElement.classList.remove("dark")}else{document.documentElement.classList.add("dark")}}catch(e){}})();` }} />
+      </head>
       <body className={`font-sans antialiased ${vazirmatn.variable}`} suppressHydrationWarning>
-        <MobileWall />
-        {children}
+        <ThemeProvider attribute="class" defaultTheme="light" storageKey="nodepad-theme-v2" enableSystem={false} disableTransitionOnChange>
+          <MobileWall />
+          {children}
+        </ThemeProvider>
         {/* Umami analytics — nodepad.space only. Remove or replace with your
             own data-website-id if self-hosting. Safe to delete entirely. */}
         <Script

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1038,8 +1038,8 @@ export default function Page() {
               transition={{ duration: 0.15, ease: "easeOut" }}
               className="absolute bottom-[72px] left-1/2 -translate-x-1/2 z-[130] pointer-events-none"
             >
-              <div className="px-3 py-1.5 rounded-sm bg-black/90 border border-white/15 backdrop-blur-md shadow-xl">
-                <span className="font-mono text-[10px] text-white/70 tracking-tight whitespace-nowrap">{undoToast}</span>
+              <div className="px-3 py-1.5 rounded-sm bg-foreground/90 border border-border backdrop-blur-md shadow-xl">
+                <span className="font-mono text-[10px] text-background tracking-tight whitespace-nowrap">{undoToast}</span>
               </div>
             </motion.div>
           )}

--- a/components/about-panel.tsx
+++ b/components/about-panel.tsx
@@ -177,7 +177,7 @@ export function AboutPanel({ open, onClose }: AboutPanelProps) {
           <Section title="Quick start">
             <div className="space-y-4">
               <Step n={1} title="Add your API key">
-                Open the sidebar (☰ top-left) → Settings. The default provider is OpenRouter — create a free account at openrouter.ai and paste your key. You can use <strong className="text-foreground/80">free models</strong> (Nemotron 30B or 120B) with no credits, or add credits to access GPT-4o, Claude Sonnet, Gemini 2.5 Pro, and DeepSeek. OpenAI and Z.ai are also supported as direct providers.
+                Open the sidebar (☰ top-left) → Settings. The default provider is OpenRouter — create a free account at openrouter.ai and paste your key. You can use <strong className="text-foreground/80">free models</strong> (Nemotron 30B or 120B) with no credits, or add credits to access GPT-4o, Claude Sonnet, Gemini 2.5 Pro, and DeepSeek. OpenAI, Anthropic, and Z.ai are also supported as direct providers.
               </Step>
               <Step n={2} title="Capture anything">
                 Type a thought, paste a quote, drop a URL, or write a question into the input bar at the bottom and press Enter. nodepad classifies it automatically.

--- a/components/about-panel.tsx
+++ b/components/about-panel.tsx
@@ -136,7 +136,7 @@ export function AboutPanel({ open, onClose }: AboutPanelProps) {
               href="https://github.com/mskayyali/nodepad"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-muted-foreground/50 hover:text-foreground border border-white/10 hover:border-white/25 px-2 py-0.5 rounded-sm transition-colors"
+              className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-muted-foreground/50 hover:text-foreground border border-border hover:border-muted-foreground/20 px-2 py-0.5 rounded-sm transition-colors"
             >
               Source code ↗
             </a>

--- a/components/ghost-panel.tsx
+++ b/components/ghost-panel.tsx
@@ -26,7 +26,7 @@ export function GhostPanel({ ghostNotes, isOpen, onClose, onClaim, onDismiss }: 
         opacity: isOpen ? 1 : 0,
         visibility: isOpen ? "visible" : "hidden",
       }}
-      className="flex flex-col h-full bg-black/20 backdrop-blur-3xl border-l border-border shrink-0 overflow-hidden relative z-50 transition-all duration-200 ease-in-out"
+      className="flex flex-col h-full bg-secondary/30 backdrop-blur-3xl border-l border-border shrink-0 overflow-hidden relative z-50 transition-all duration-200 ease-in-out"
     >
       <div className="w-[272px] flex flex-col h-full">
         {/* Header */}
@@ -46,7 +46,7 @@ export function GhostPanel({ ghostNotes, isOpen, onClose, onClaim, onDismiss }: 
           </div>
           <button
             onClick={onClose}
-            className="p-1 px-1.5 hover:bg-white/5 rounded-sm transition-colors text-muted-foreground/30 hover:text-white"
+            className="p-1 px-1.5 hover:bg-muted/30 rounded-sm transition-colors text-muted-foreground/30 hover:text-foreground"
           >
             <X className="h-3.5 w-3.5" />
           </button>

--- a/components/graph-area.tsx
+++ b/components/graph-area.tsx
@@ -419,7 +419,7 @@ export function GraphArea({
                 ))}
               </div>
 
-              <p className="text-[13px] text-white uppercase tracking-[0.15em] whitespace-nowrap">
+              <p className="text-[13px] text-muted-foreground uppercase tracking-[0.15em] whitespace-nowrap">
                 {`type anything · #type to classify · ${mod}K for commands`}
               </p>
             </div>
@@ -647,7 +647,7 @@ export function GraphArea({
                           xmlns="http://www.w3.org/1999/xhtml"
                           style={{ width: 34, height: 34, display: "flex", alignItems: "center", justifyContent: "center" }}
                         >
-                          <Icon style={{ width: 19, height: 19, color: "white", opacity: 0.92 }} />
+                          <Icon style={{ width: 19, height: 19, opacity: 0.92 }} />
                         </div>
                       </foreignObject>
                     )}
@@ -701,15 +701,14 @@ export function GraphArea({
               style={{ left: tipX, top: tipY, transform: "translateY(-100%)" }}
             >
               <div
-                className="rounded-sm shadow-[0_4px_24px_rgba(0,0,0,0.55)] border border-white/10 overflow-hidden"
+                className="rounded-sm shadow-[0_4px_24px_rgba(0,0,0,0.2)] border border-border overflow-hidden"
                 style={{ minWidth: 190, maxWidth: 300 }}
               >
                 <div className="flex items-center gap-2 px-2.5 py-1.5" style={{ background: accent }}>
                   {config?.icon && React.createElement(config.icon, {
-                    className: "h-3 w-3 flex-shrink-0",
-                    style: { color: "black", opacity: 0.7 },
+                    className: "h-3 w-3 flex-shrink-0 text-white/70",
                   })}
-                  <span className="font-mono text-[9px] font-black uppercase tracking-widest text-black/70">
+                  <span className="font-mono text-[9px] font-black uppercase tracking-widest text-white/70">
                     {node.isSynthesis ? "Synthesis" : config?.label}
                   </span>
                   {node.block?.category && (
@@ -728,7 +727,7 @@ export function GraphArea({
                 </div>
               </div>
               <div
-                className="mx-4 h-2 w-2 rotate-45 border-b border-r border-white/10 bg-card/95"
+                className="mx-4 h-2 w-2 rotate-45 border-b border-r border-border bg-card/95"
                 style={{ marginTop: -1 }}
               />
             </div>

--- a/components/graph-area.tsx
+++ b/components/graph-area.tsx
@@ -468,8 +468,8 @@ export function GraphArea({
             dominantBaseline="central"
             fontSize={Math.max(11, 11 * tk)}
             fontFamily="monospace"
-            fill="white"
-            fillOpacity={Math.max(0, 0.06 - (nodesRef.current.length * 0.002))}
+            fill="var(--foreground)"
+            fillOpacity={Math.max(0, 0.05 - (nodesRef.current.length * 0.002))}
             style={{ pointerEvents: "none", userSelect: "none", letterSpacing: "0.08em" }}
           >
             {projectName.toUpperCase()}
@@ -498,7 +498,7 @@ export function GraphArea({
                   <path
                     key={i}
                     d={d}
-                    stroke="white"
+                    stroke="var(--foreground)"
                     strokeWidth={isSynth ? 0.5 : highlighted ? 2 : 1.2}
                     strokeDasharray={isSynth ? "3 7" : undefined}
                     strokeOpacity={
@@ -532,7 +532,7 @@ export function GraphArea({
                 const Icon   = config?.icon ?? null
                 const accent = config?.accentVar ?? "var(--type-thesis)"
 
-                const fill = node.isSynthesis ? "url(#synth-grad)" : (config?.accentVar ?? "white")
+                const fill = node.isSynthesis ? "url(#synth-grad)" : (config?.accentVar ?? "var(--foreground)")
 
                 // Short label: first 4 words, truncated at 22 chars
                 const labelWords = (node.block?.text ?? "").split(/\s+/).slice(0, 4).join(" ")
@@ -647,7 +647,7 @@ export function GraphArea({
                           xmlns="http://www.w3.org/1999/xhtml"
                           style={{ width: 34, height: 34, display: "flex", alignItems: "center", justifyContent: "center" }}
                         >
-                          <Icon style={{ width: 19, height: 19, opacity: 0.92 }} />
+                          <Icon style={{ width: 19, height: 19, color: "var(--primary-foreground)", opacity: 0.92 }} />
                         </div>
                       </foreignObject>
                     )}
@@ -658,7 +658,7 @@ export function GraphArea({
                         textAnchor="middle"
                         dominantBaseline="central"
                         fontSize={13}
-                        fill="white"
+                        fill="var(--foreground)"
                         fillOpacity={0.9}
                         style={{ pointerEvents: "none" }}
                       >

--- a/components/graph-detail-panel.tsx
+++ b/components/graph-detail-panel.tsx
@@ -150,9 +150,9 @@ export function GraphDetailPanel({
   const headerBg = block.contentType === "thesis"
     ? "var(--thesis-gradient)"
     : block.isPinned
-      ? `linear-gradient(to right, ${accent}, color-mix(in oklch, ${accent} 80%, white 10%))`
+      ? `linear-gradient(to right, ${accent}, color-mix(in oklch, ${accent} 60%, black 15%))`
       : accent
-  const headerColor = block.contentType === "thesis" ? "var(--thesis-foreground)" : "black"
+  const headerColor = block.contentType === "thesis" ? "var(--thesis-foreground)" : "white"
 
   const connectedBlocks = allBlocks.filter(
     b => b.id !== block.id && (
@@ -192,7 +192,7 @@ export function GraphDetailPanel({
             {config.label}
           </span>
           {/* Category tag — read-only, updated by AI on enrichment */}
-          <span className="rounded-sm bg-black/10 px-1.5 py-0.5 font-mono text-[8px] font-black uppercase tracking-tighter opacity-60">
+          <span className="rounded-sm bg-muted/20 px-1.5 py-0.5 font-mono text-[8px] font-black uppercase tracking-tighter opacity-60">
             #{block.category || "no-topic"}
           </span>
         </div>
@@ -207,7 +207,7 @@ export function GraphDetailPanel({
               }
               setIsTypePickerOpen(v => !v)
             }}
-            className={`p-1 rounded-sm transition-opacity ${isTypePickerOpen ? "opacity-100 bg-black/20" : "opacity-40 hover:opacity-90"}`}
+            className={`p-1 rounded-sm transition-opacity ${isTypePickerOpen ? "opacity-100 bg-muted/40" : "opacity-40 hover:opacity-90"}`}
             title="Change type"
           >
             <Tag className="h-3 w-3" />

--- a/components/intro-modal.tsx
+++ b/components/intro-modal.tsx
@@ -36,7 +36,7 @@ export function IntroModal({ open, onClose }: IntroModalProps) {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.25 }}
-          className="fixed inset-0 z-[500] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+          className="fixed inset-0 z-[500] flex items-center justify-center bg-background/80 backdrop-blur-sm p-4"
           onClick={(e) => { if (e.target === overlayRef.current) onClose() }}
         >
           <motion.div
@@ -44,7 +44,7 @@ export function IntroModal({ open, onClose }: IntroModalProps) {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 8 }}
             transition={{ duration: 0.25, ease: "easeOut" }}
-            className="relative w-full max-w-3xl bg-[#0d0d0d] border border-white/10 rounded-sm shadow-2xl overflow-hidden"
+            className="relative w-full max-w-3xl bg-card border border-border rounded-sm shadow-2xl overflow-hidden"
           >
             {/* Header */}
             <div className="flex items-center justify-between px-6 pt-6 pb-4">
@@ -63,7 +63,7 @@ export function IntroModal({ open, onClose }: IntroModalProps) {
               </div>
               <button
                 onClick={onClose}
-                className="p-1.5 rounded-sm text-muted-foreground/40 hover:text-foreground hover:bg-white/10 transition-colors"
+                className="p-1.5 rounded-sm text-muted-foreground/40 hover:text-foreground hover:bg-muted/30 transition-colors"
                 aria-label="Close"
               >
                 <X className="h-4 w-4" />
@@ -82,13 +82,13 @@ export function IntroModal({ open, onClose }: IntroModalProps) {
             </div>
 
             {/* Footer */}
-            <div className="flex items-center justify-between px-6 py-4 border-t border-white/[0.06]">
+            <div className="flex items-center justify-between px-6 py-4 border-t border-border">
               <p className="text-xs text-muted-foreground/40">
                 You can replay this anytime via the <span className="font-mono font-black text-muted-foreground/60">?</span> button
               </p>
               <button
                 onClick={onClose}
-                className="px-4 py-1.5 text-xs font-mono font-medium rounded-sm bg-white/8 hover:bg-white/15 text-foreground/70 hover:text-foreground border border-white/10 hover:border-white/20 transition-all"
+                className="px-4 py-1.5 text-xs font-mono font-medium rounded-sm bg-muted/20 hover:bg-muted/40 text-foreground/70 hover:text-foreground border border-border hover:border-muted-foreground/20 transition-all"
               >
                 Skip to app →
               </button>

--- a/components/kanban-area.tsx
+++ b/components/kanban-area.tsx
@@ -116,7 +116,7 @@ export function KanbanArea({
   }, [columns])
 
   return (
-    <div className="relative h-full w-full bg-[#050505] overflow-hidden">
+    <div className="relative h-full w-full bg-background overflow-hidden">
       {/* Scrollable Container */}
       <div 
         ref={containerRef}
@@ -209,7 +209,7 @@ export function KanbanArea({
             </div>
 
 
-            <p className="text-[13px] text-white uppercase tracking-[0.15em] whitespace-nowrap">
+            <p className="text-[13px] text-muted-foreground uppercase tracking-[0.15em] whitespace-nowrap">
               {`type anything · #type to classify · ${mod}K for commands`}
             </p>
           </div>

--- a/components/kanban-minimap.tsx
+++ b/components/kanban-minimap.tsx
@@ -19,12 +19,12 @@ export function KanbanMinimap({ columns, onColumnClick }: KanbanMinimapProps) {
   if (columns.length === 0) return null
 
   return (
-    <div className="flex items-center gap-1.5 p-1 rounded-lg bg-black/10 backdrop-blur-md border border-white/5 shadow-xl transition-all hover:bg-black/20">
+    <div className="flex items-center gap-1.5 p-1 rounded-lg bg-secondary/30 backdrop-blur-md border border-border shadow-xl transition-all hover:bg-secondary/50">
       {columns.map((col) => (
         <button
           key={col.id}
           onClick={() => onColumnClick(col.id)}
-          className="group relative flex items-center justify-center h-8 w-8 rounded-md hover:bg-white/10 transition-all active:scale-95"
+          className="group relative flex items-center justify-center h-8 w-8 rounded-md hover:bg-muted/30 transition-all active:scale-95"
           title={col.title}
         >
           <col.icon className="h-4 w-4 text-foreground/60 group-hover:text-foreground transition-colors" />

--- a/components/project-sidebar.tsx
+++ b/components/project-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react"
 import { motion, AnimatePresence } from "framer-motion"
+import { useTheme } from "next-themes"
 import {
   Plus,
   Settings,
@@ -14,6 +15,8 @@ import {
   Key,
   ChevronDown,
   Globe,
+  Sun,
+  Moon,
   Eye,
   EyeOff,
   Save,
@@ -74,6 +77,9 @@ export function ProjectSidebar({
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [showSettings, setShowSettings] = useState(false)
   const [showKey, setShowKey] = useState(false)
+  const { theme, setTheme, resolvedTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+  const [flipping, setFlipping] = useState(false)
   const [modelOpen, setModelOpen] = useState(false)
   const [providerOpen, setProviderOpen] = useState(false)
   const [fetchedModels, setFetchedModels] = useState<FetchedModel[]>([])
@@ -90,6 +96,8 @@ export function ProjectSidebar({
       inputRef.current.select()
     }
   }, [editingId])
+
+  useEffect(() => { setMounted(true) }, [])
 
   // Sync draft when panel opens
   useEffect(() => {
@@ -180,7 +188,7 @@ export function ProjectSidebar({
         opacity: isOpen ? 1 : 0,
         visibility: isOpen ? "visible" : "hidden"
       }}
-      className="relative z-50 transition-all duration-200 ease-in-out overflow-hidden border-r border-border bg-black/20 backdrop-blur-3xl flex flex-col h-full"
+      className="relative z-50 transition-all duration-200 ease-in-out overflow-hidden border-r border-border bg-secondary/30 backdrop-blur-3xl flex flex-col h-full"
     >
       <div style={{ width: showSettings ? 320 : 240 }} className="flex flex-col h-full">
         {/* Header */}
@@ -207,7 +215,7 @@ export function ProjectSidebar({
           </div>
           <button
             onClick={handleClose}
-            className="p-1 px-1.5 hover:bg-white/5 rounded-sm transition-colors text-muted-foreground hover:text-foreground"
+            className="p-1 px-1.5 hover:bg-primary/5 rounded-sm transition-colors text-muted-foreground hover:text-foreground"
           >
             <X className="h-3.5 w-3.5" />
           </button>
@@ -231,7 +239,7 @@ export function ProjectSidebar({
                     className={`group relative rounded-sm transition-all duration-150 ${
                       activeProjectId === project.id 
                         ? "bg-primary/10 shadow-[inset_0_1px_0px_rgba(255,255,255,0.05)]" 
-                        : "hover:bg-white/5"
+                        : "hover:bg-primary/5"
                     }`}
                   >
                     <div className="flex items-center p-2 px-2.5">
@@ -272,7 +280,7 @@ export function ProjectSidebar({
                                 setEditName(project.name)
                                 setEditingId(project.id)
                               }}
-                              className="p-1 hover:bg-white/10 rounded-sm text-muted-foreground hover:text-primary transition-colors"
+                              className="p-1 hover:bg-muted/30 rounded-sm text-muted-foreground hover:text-primary transition-colors"
                             >
                               <Edit3 className="h-3 w-3" />
                             </button>
@@ -336,16 +344,16 @@ export function ProjectSidebar({
               >
                 {/* Provider Selector */}
                 <div className="flex flex-col gap-2">
-                  <label className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+                  <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
                     Provider
                   </label>
                   <div className="relative">
                     <button
                       onClick={() => setProviderOpen(v => !v)}
-                      className="flex w-full items-center justify-between rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-2 text-left hover:bg-white/[0.07] focus:outline-none transition-colors"
+                      className="flex w-full items-center justify-between rounded-md border border-border bg-muted/30 px-2.5 py-2 text-left hover:bg-muted/50 focus:outline-none transition-colors"
                     >
-                      <span className="font-mono text-[11px] font-bold text-foreground">{currentPreset.label}</span>
-                      <ChevronDown className={`h-3 w-3 text-muted-foreground transition-transform ${providerOpen ? "rotate-180" : ""}`} />
+                      <span className="font-mono text-xs font-bold text-foreground">{currentPreset.label}</span>
+                      <ChevronDown className={`h-3.5 w-3.5 text-muted-foreground transition-transform ${providerOpen ? "rotate-180" : ""}`} />
                     </button>
                     <AnimatePresence>
                       {providerOpen && (
@@ -354,7 +362,7 @@ export function ProjectSidebar({
                           animate={{ opacity: 1, y: 0 }}
                           exit={{ opacity: 0, y: -4 }}
                           transition={{ duration: 0.1 }}
-                          className="absolute top-full left-0 right-0 z-20 mt-1 overflow-hidden rounded-md border border-white/10 bg-[#0d0d10] shadow-xl"
+                          className="absolute top-full left-0 right-0 z-20 mt-1 overflow-hidden rounded-md border border-border bg-card shadow-xl"
                         >
                           {AI_PROVIDER_PRESETS.map(preset => (
                             <button
@@ -373,14 +381,14 @@ export function ProjectSidebar({
                                 }))
                                 setProviderOpen(false)
                               }}
-                              className="flex w-full items-center gap-2.5 px-2.5 py-2 text-left hover:bg-white/5 transition-colors"
+                              className="flex w-full items-center gap-2.5 px-2.5 py-2 text-left hover:bg-primary/5 transition-colors"
                             >
                               <div className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border ${
-                                draft.provider === preset.id ? "border-primary bg-primary/20" : "border-white/10"
+                                draft.provider === preset.id ? "border-primary bg-primary/20" : "border-border"
                               }`}>
                                 {draft.provider === preset.id && <Check className="h-2.5 w-2.5 text-primary" />}
                               </div>
-                              <span className="font-mono text-[10px] font-bold text-foreground">{preset.label}</span>
+                              <span className="font-mono text-[11px] font-bold text-foreground">{preset.label}</span>
                             </button>
                           ))}
                         </motion.div>
@@ -391,17 +399,17 @@ export function ProjectSidebar({
 
                 {/* API Key */}
                 <div className="flex flex-col gap-2">
-                  <label className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+                  <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
                     API Key
                   </label>
-                  <div className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-2 focus-within:border-primary/50 transition-colors">
+                  <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-2 focus-within:border-primary/50 transition-colors">
                     <Key className="h-3 w-3 shrink-0 text-muted-foreground" />
                     <input
                       type="text"
                       value={draft.apiKey}
                       onChange={e => setDraft(d => ({ ...d, apiKey: e.target.value }))}
                       placeholder={currentPreset.keyPlaceholder || "Your API key"}
-                      className="flex-1 bg-transparent font-mono text-[11px] text-foreground outline-none placeholder:text-muted-foreground/40"
+                      className="flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground/40"
                       style={showKey ? undefined : { WebkitTextSecurity: "disc" } as never}
                       autoComplete="off"
                       spellCheck={false}
@@ -423,16 +431,16 @@ export function ProjectSidebar({
 
                 {/* Custom Base URL */}
                 <div className="flex flex-col gap-2">
-                  <label className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+                  <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
                     Custom Base URL
                   </label>
-                  <div className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-2 focus-within:border-primary/50 transition-colors">
+                  <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-2 focus-within:border-primary/50 transition-colors">
                     <input
                       type="text"
                       value={draft.customBaseUrl ?? ""}
                       onChange={e => setDraft(d => ({ ...d, customBaseUrl: e.target.value }))}
                       placeholder="Optional — for local/self-hosted endpoints"
-                      className="flex-1 bg-transparent font-mono text-[11px] text-foreground outline-none placeholder:text-muted-foreground/40"
+                      className="flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground/40"
                       autoComplete="off"
                       spellCheck={false}
                     />
@@ -444,17 +452,17 @@ export function ProjectSidebar({
 
                 {/* Model Selector */}
                 <div className="flex flex-col gap-2">
-                  <label className="font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+                  <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
                     Model
                   </label>
                   {models.length === 0 ? (
-                    <div className="flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-2 focus-within:border-primary/50 transition-colors">
+                    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-2.5 py-2 focus-within:border-primary/50 transition-colors">
                       <input
                         type="text"
                         value={draft.modelId}
                         onChange={e => setDraft(d => ({ ...d, modelId: e.target.value }))}
                         placeholder="e.g. gpt-4o, claude-3-opus-20240229"
-                        className="flex-1 bg-transparent font-mono text-[11px] text-foreground outline-none placeholder:text-muted-foreground/40"
+                        className="flex-1 bg-transparent font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground/40"
                         autoComplete="off"
                         spellCheck={false}
                       />
@@ -463,11 +471,11 @@ export function ProjectSidebar({
                     <div>
                       <button
                         onClick={() => { setModelOpen(v => { if (v) setModelSearch(""); return !v }) }}
-                        className="flex w-full items-center justify-between rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-2 text-left hover:bg-white/[0.07] focus:outline-none transition-colors"
+                        className="flex w-full items-center justify-between rounded-md border border-border bg-muted/30 px-2.5 py-2 text-left hover:bg-muted/50 focus:outline-none transition-colors"
                       >
                         <div>
                           <div className="font-mono text-[11px] font-bold text-foreground">{selectedModel?.label ?? draft.modelId}</div>
-                          <div className="font-mono text-[9px] text-muted-foreground mt-0.5">{selectedModel?.description ?? "Custom model ID"}</div>
+                          <div className="font-mono text-[10px] text-muted-foreground mt-0.5">{selectedModel?.description ?? "Custom model ID"}</div>
                         </div>
                         <ChevronDown className={`h-3 w-3 text-muted-foreground transition-transform ${modelOpen ? "rotate-180" : ""}`} />
                       </button>
@@ -478,10 +486,10 @@ export function ProjectSidebar({
                             animate={{ opacity: 1, height: "auto" }}
                             exit={{ opacity: 0, height: 0 }}
                             transition={{ duration: 0.15 }}
-                            className="mt-1 overflow-hidden rounded-md border border-white/10 bg-[#0d0d10] shadow-xl"
+                            className="mt-1 overflow-hidden rounded-md border border-border bg-card shadow-xl"
                           >
                             {/* Search input */}
-                            <div className="flex items-center gap-2 px-2.5 py-2 border-b border-white/5">
+                            <div className="flex items-center gap-2 px-2.5 py-2 border-b border-border">
                               <Search className="h-3 w-3 shrink-0 text-muted-foreground/50" />
                               <input
                                 type="text"
@@ -505,10 +513,10 @@ export function ProjectSidebar({
                                       setModelOpen(false)
                                       setModelSearch("")
                                     }}
-                                    className="flex w-full items-center gap-2.5 px-2.5 py-2 text-left hover:bg-white/5 transition-colors"
+                                    className="flex w-full items-center gap-2.5 px-2.5 py-2 text-left hover:bg-primary/5 transition-colors"
                                   >
                                     <div className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border ${
-                                      draft.modelId === model.id ? "border-primary bg-primary/20" : "border-white/10"
+                                      draft.modelId === model.id ? "border-primary bg-primary/20" : "border-border"
                                     }`}>
                                       {draft.modelId === model.id && <Check className="h-2.5 w-2.5 text-primary" />}
                                     </div>
@@ -523,7 +531,7 @@ export function ProjectSidebar({
                               {/* Fetched models from provider API */}
                               {fetchedModels.length > 0 && (
                                 <>
-                                  <div className="px-2.5 py-1.5 border-t border-white/5">
+                                  <div className="px-2.5 py-1.5 border-t border-border">
                                     <span className="font-sans text-[8px] font-semibold uppercase tracking-widest text-muted-foreground/50">
                                       All available models ({fetchedModels.length})
                                     </span>
@@ -552,10 +560,10 @@ export function ProjectSidebar({
                                             setModelOpen(false)
                                             setModelSearch("")
                                           }}
-                                          className="flex w-full items-center gap-2.5 px-2.5 py-1.5 text-left hover:bg-white/5 transition-colors"
+                                          className="flex w-full items-center gap-2.5 px-2.5 py-1.5 text-left hover:bg-primary/5 transition-colors"
                                         >
                                           <div className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border ${
-                                            draft.modelId === fm.id ? "border-primary bg-primary/20" : "border-white/10"
+                                            draft.modelId === fm.id ? "border-primary bg-primary/20" : "border-border"
                                           }`}>
                                             {draft.modelId === fm.id && <Check className="h-2.5 w-2.5 text-primary" />}
                                           </div>
@@ -583,7 +591,7 @@ export function ProjectSidebar({
                                 </div>
                               )}
                               {fetchError && !fetchingModels && (
-                                <div className="px-2.5 py-2 border-t border-white/5">
+                                <div className="px-2.5 py-2 border-t border-border">
                                   <span className="font-sans text-[9px] text-destructive/70">{fetchError}</span>
                                 </div>
                               )}
@@ -607,7 +615,7 @@ export function ProjectSidebar({
 
                 {/* Web Grounding (OpenRouter + OpenAI) */}
                 {(draft.provider === "openrouter" || draft.provider === "openai") && selectedModel && (
-                  <div className="flex items-start justify-between gap-3 rounded-md border border-white/5 bg-white/[0.02] px-2.5 py-2.5">
+                  <div className="flex items-start justify-between gap-3 rounded-md border border-border bg-muted/20 px-2.5 py-2.5">
                     <div className="flex items-start gap-2">
                       <Globe className="h-3.5 w-3.5 mt-0.5 text-primary/60 shrink-0" />
                       <div>
@@ -625,7 +633,7 @@ export function ProjectSidebar({
                       onClick={() => selectedModel.supportsGrounding && setDraft(d => ({ ...d, webGrounding: !d.webGrounding }))}
                       disabled={!selectedModel.supportsGrounding}
                       className={`relative shrink-0 h-5 w-9 rounded-full transition-all duration-200 ${
-                        draft.webGrounding && selectedModel.supportsGrounding ? "bg-primary" : "bg-white/10"
+                        draft.webGrounding && selectedModel.supportsGrounding ? "bg-primary" : "bg-muted-foreground/30"
                       } disabled:opacity-30 disabled:cursor-not-allowed`}
                     >
                       <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all duration-200 ${
@@ -639,18 +647,66 @@ export function ProjectSidebar({
                 <div className={`flex items-center gap-2 rounded-md px-2.5 py-2 font-mono text-[9px] ${
                   draft.apiKey
                     ? "bg-primary/10 border border-primary/20 text-primary"
-                    : "bg-white/5 border border-white/5 text-muted-foreground"
+                    : "bg-muted/30 border border-border text-muted-foreground"
                 }`}>
-                  <span className={`h-1.5 w-1.5 rounded-full ${draft.apiKey ? "bg-primary animate-pulse" : "bg-white/30"}`} />
+                  <span className={`h-1.5 w-1.5 rounded-full ${draft.apiKey ? "bg-primary animate-pulse" : "bg-muted-foreground/30"}`} />
                   {draft.apiKey ? `${currentPreset.label} — API key configured` : "No API key — AI disabled"}
                 </div>
+
+                {/* Theme Toggle */}
+                {mounted && (
+                  <button
+                    onClick={() => {
+                      setFlipping(true)
+                      setTheme(resolvedTheme === "dark" ? "light" : "dark")
+                      setTimeout(() => setFlipping(false), 400)
+                    }}
+                    className="flex w-full items-center justify-between rounded-md border border-border bg-muted/30 px-2.5 py-2.5 text-left hover:bg-muted/50 focus:outline-none transition-colors"
+                  >
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <div className="relative h-5 w-5 shrink-0 overflow-hidden">
+                        <AnimatePresence mode="wait" initial={false}>
+                          {resolvedTheme === "dark" ? (
+                            <motion.div
+                              key="moon"
+                              initial={{ y: 14, opacity: 0 }}
+                              animate={{ y: 0, opacity: 1 }}
+                              exit={{ y: -14, opacity: 0 }}
+                              transition={{ duration: 0.2, ease: "easeInOut" }}
+                              className="absolute inset-0 flex items-center justify-center"
+                            >
+                              <Moon className="h-5 w-5 text-primary" />
+                            </motion.div>
+                          ) : (
+                            <motion.div
+                              key="sun"
+                              initial={{ y: 14, opacity: 0 }}
+                              animate={{ y: 0, opacity: 1 }}
+                              exit={{ y: -14, opacity: 0 }}
+                              transition={{ duration: 0.2, ease: "easeInOut" }}
+                              className="absolute inset-0 flex items-center justify-center"
+                            >
+                              <Sun className="h-5 w-5 text-primary" />
+                            </motion.div>
+                          )}
+                        </AnimatePresence>
+                      </div>
+                      <div className="min-w-0">
+                        <div className="font-mono text-xs font-bold text-foreground truncate">Interface Theme</div>
+                        <div className="font-mono text-[10px] text-muted-foreground mt-0.5 leading-relaxed">
+                          {resolvedTheme === "dark" ? "Dark" : "Light"} mode
+                        </div>
+                      </div>
+                    </div>
+                  </button>
+                )}
               </motion.div>
             )}
           </AnimatePresence>
         </div>
 
         {/* Footer */}
-        <div className="p-3 border-t border-white/5 bg-black/10 shrink-0">
+        <div className="p-3 border-t border-border bg-muted/10 shrink-0">
           {showSettings ? (
             <div className="flex flex-col gap-1.5">
               <button
@@ -662,7 +718,7 @@ export function ProjectSidebar({
               </button>
               <button
                 onClick={() => setShowSettings(false)}
-                className="flex items-center justify-center w-full h-8 px-2.5 rounded-sm bg-white/5 hover:bg-white/10 text-muted-foreground font-mono text-[9px] font-bold uppercase tracking-[0.1em] transition-all active:scale-[0.98] border border-white/5"
+                className="flex items-center justify-center w-full h-8 px-2.5 rounded-sm bg-muted/20 hover:bg-muted/40 text-muted-foreground font-mono text-[9px] font-bold uppercase tracking-[0.1em] transition-all active:scale-[0.98] border border-border"
               >
                 Cancel
               </button>
@@ -678,7 +734,7 @@ export function ProjectSidebar({
               </button>
               <button
                 onClick={onImportProject}
-                className="flex items-center justify-between w-full h-8 px-2.5 rounded-sm bg-white/5 hover:bg-white/10 text-muted-foreground hover:text-foreground font-mono text-[9px] font-bold uppercase tracking-[0.1em] transition-all active:scale-[0.98] border border-white/5"
+                className="flex items-center justify-between w-full h-8 px-2.5 rounded-sm bg-muted/20 hover:bg-muted/40 text-muted-foreground hover:text-foreground font-mono text-[9px] font-bold uppercase tracking-[0.1em] transition-all active:scale-[0.98] border border-border"
                 title="Import a .nodepad file"
               >
                 <span>Import .nodepad</span>
@@ -686,7 +742,7 @@ export function ProjectSidebar({
               </button>
               <button
                 onClick={() => setShowSettings(true)}
-                className="flex items-center justify-between w-full h-8 px-2.5 rounded-sm bg-white/5 hover:bg-white/10 text-muted-foreground hover:text-foreground font-mono text-[9px] font-bold uppercase tracking-[0.1em] transition-all active:scale-[0.98] border border-white/5"
+                className="flex items-center justify-between w-full h-8 px-2.5 rounded-sm bg-muted/20 hover:bg-muted/40 text-muted-foreground hover:text-foreground font-mono text-[9px] font-bold uppercase tracking-[0.1em] transition-all active:scale-[0.98] border border-border"
               >
                 <span>Settings</span>
                 <Settings className="h-3.5 w-3.5" />

--- a/components/status-bar.tsx
+++ b/components/status-bar.tsx
@@ -153,7 +153,7 @@ export function StatusBar({
             )}
           </div>
         )}
-        <div className="flex items-center gap-2 border-l border-white/5 pl-4 ml-4">
+        <div className="flex items-center gap-2 border-l border-border pl-4 ml-4">
           {/* Model indicator */}
           {modelLabel && (
             <span className="font-mono text-[9px] text-muted-foreground/60 uppercase tracking-wider px-1.5">

--- a/components/tile-card.tsx
+++ b/components/tile-card.tsx
@@ -345,17 +345,15 @@ export const TileCard = memo(function TileCard({
         style={{ 
           borderBottom: effectiveCollapsed ? "none" : "1px solid var(--border)",
           background: isTask
-            ? "linear-gradient(to right, oklch(0.25 0.08 260), oklch(0.18 0.05 260))"
+            ? "linear-gradient(to right, oklch(0.3 0.08 260), oklch(0.22 0.05 260))"
             : block.contentType === "thesis"
               ? "var(--thesis-gradient)"
               : block.isPinned
-                ? `linear-gradient(to right, ${accent}, color-mix(in oklch, ${accent} 80%, white 10%))`
+                ? `linear-gradient(to right, ${accent}, color-mix(in oklch, ${accent} 60%, black 15%))`
                 : accent,
-          color: isTask 
-            ? "oklch(0.85 0.05 260)" 
-            : block.contentType === "thesis" 
+          color: block.contentType === "thesis" 
               ? "var(--thesis-foreground)" 
-              : "black"
+              : "white"
         }}
       >
         <div className={`flex items-center gap-2 overflow-hidden ${isTextRTL ? 'flex-row-reverse' : ''}`} style={{ color: "inherit" }}>
@@ -380,7 +378,7 @@ export const TileCard = memo(function TileCard({
           </span>
 
           {block.isUnrelated && !effectiveCollapsed && (
-            <span className="ml-1 rounded-sm bg-black/10 px-1.5 py-0.5 font-mono text-[8px] font-black uppercase tracking-tighter text-black/60">
+            <span className="ml-1 rounded-sm bg-muted/30 px-1.5 py-0.5 font-mono text-[8px] font-black uppercase tracking-tighter text-foreground/60">
               Not related to topic
             </span>
           )}
@@ -399,7 +397,7 @@ export const TileCard = memo(function TileCard({
               }}
               className={`flex items-center gap-[2.5px] transition-all duration-150 rounded-sm px-0.5 ${
                 isConnectionLocked
-                  ? "opacity-100 bg-black/20"
+                  ? "opacity-100 bg-muted/40"
                   : "opacity-35 hover:opacity-90"
               }`}
               title={isConnectionLocked ? "Click to unlock connections" : `Show ${block.influencedBy.length} connection${block.influencedBy.length !== 1 ? 's' : ''} — click to lock`}
@@ -418,7 +416,7 @@ export const TileCard = memo(function TileCard({
                 e.stopPropagation()
                 onReEnrich(block.id, "thesis")
               }}
-              className="flex h-4 w-4 items-center justify-center rounded-sm transition-all hover:bg-black/20"
+              className="flex h-4 w-4 items-center justify-center rounded-sm transition-all hover:bg-muted/30"
               title="Refresh thesis synthesis"
               disabled={block.isEnriching}
             >
@@ -431,7 +429,7 @@ export const TileCard = memo(function TileCard({
                 e.stopPropagation()
                 onTogglePin(block.id)
               }}
-              className={`flex h-4 w-4 items-center justify-center rounded-sm transition-all shadow-sm ${block.isPinned ? "bg-black/20 opacity-100 scale-110 !opacity-100" : "opacity-40 hover:opacity-100 hover:bg-black/10"}`}
+              className={`flex h-4 w-4 items-center justify-center rounded-sm transition-all shadow-sm ${block.isPinned ? "bg-muted/40 opacity-100 scale-110 !opacity-100" : "opacity-40 hover:opacity-100 hover:bg-muted/30"}`}
               aria-label={block.isPinned ? "Unpin note" : "Pin note"}
               title={block.isPinned ? "Unpin note" : "Pin note"}
             >
@@ -449,7 +447,7 @@ export const TileCard = memo(function TileCard({
                 }
                 setIsMoveMenuOpen(v => !v)
               }}
-              className={`flex h-4 w-4 items-center justify-center rounded-sm transition-all ${isMoveMenuOpen ? "bg-black/20 opacity-100" : "opacity-40 hover:opacity-100 hover:bg-black/10"}`}
+              className={`flex h-4 w-4 items-center justify-center rounded-sm transition-all ${isMoveMenuOpen ? "bg-muted/40 opacity-100" : "opacity-40 hover:opacity-100 hover:bg-muted/30"}`}
               title="Move or copy to another space"
               aria-label="Move or copy to another space"
             >
@@ -467,7 +465,7 @@ export const TileCard = memo(function TileCard({
                 }
                 setIsTypePickerOpen(v => !v)
               }}
-              className={`flex h-4 w-4 items-center justify-center rounded-sm transition-all ${isTypePickerOpen ? "bg-black/20 opacity-100" : "opacity-40 hover:opacity-100 hover:bg-black/10"}`}
+              className={`flex h-4 w-4 items-center justify-center rounded-sm transition-all ${isTypePickerOpen ? "bg-muted/40 opacity-100" : "opacity-40 hover:opacity-100 hover:bg-muted/30"}`}
               title="Change type"
             >
               <Tag className="h-2.5 w-2.5" />
@@ -478,7 +476,7 @@ export const TileCard = memo(function TileCard({
               e.stopPropagation()
               onDelete(block.id)
             }}
-            className="flex h-4 w-4 items-center justify-center rounded-sm transition-all hover:bg-black/10"
+            className="flex h-4 w-4 items-center justify-center rounded-sm transition-all hover:bg-muted/30"
             aria-label="Delete note"
           >
             <X className="h-2.5 w-2.5" />
@@ -652,7 +650,7 @@ export const TileCard = memo(function TileCard({
                       {isTask && block.subTasks ? (
                         <div className="flex flex-col gap-2">
                           {block.subTasks.map(st => (
-                            <div key={st.id} className="group/task flex items-start gap-3 rounded-md bg-white/5 p-2 transition-colors hover:bg-white/10">
+                            <div key={st.id} className="group/task flex items-start gap-3 rounded-md bg-muted/20 p-2 transition-colors hover:bg-muted/40">
                               <button
                                 onClick={() => onToggleSubTask?.(block.id, st.id)}
                                 className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-all`} style={{ backgroundColor: st.isDone ? 'var(--type-task)' : 'transparent', borderColor: st.isDone ? 'var(--type-task)' : 'color-mix(in oklch, var(--type-task) 50%, transparent)' }}
@@ -745,7 +743,7 @@ export const TileCard = memo(function TileCard({
             <div
               ref={footerRef}
               className={`relative flex flex-shrink-0 flex-col transition-all duration-300 ease-in-out ${
-                isFooterExpanded ? "bg-secondary/40" : "bg-black/25"
+                isFooterExpanded ? "bg-secondary/40" : "bg-muted/30"
               }`}
               style={{
                 borderTop: "1px solid var(--border)",
@@ -758,10 +756,9 @@ export const TileCard = memo(function TileCard({
                     <span
                       className="rounded-sm px-2 py-0.5 font-mono text-[10px] font-bold flex items-center gap-1.5 shadow-sm shrink-0"
                       style={{
-                        background: `color-mix(in oklch, ${accent} 35%, transparent)`,
-                        color: "white",
-                        border: `1px solid color-mix(in oklch, ${accent} 50%, transparent)`
-                      }}
+                  background: `color-mix(in oklch, ${accent} 35%, transparent)`,
+                  border: `1px solid color-mix(in oklch, ${accent} 50%, transparent)`
+                }}
                     >
                       <span className="opacity-70">#</span>
                       <span className="truncate max-w-[120px]">{block.category || "no-topic"}</span>
@@ -781,8 +778,8 @@ export const TileCard = memo(function TileCard({
                         </div>
 
                         {/* Hover Tooltip */}
-                        <div className="absolute bottom-full left-0 mb-2 w-56 p-2 rounded-sm bg-black/90 backdrop-blur-md border border-white/10 shadow-xl opacity-0 translate-y-2 pointer-events-none group-hover/influences:opacity-100 group-hover/influences:translate-y-0 transition-all z-[100]">
-                          <h5 className="font-mono text-[8px] font-bold text-muted-foreground uppercase tracking-widest mb-1.5 border-b border-white/5 pb-1">Connected nodes</h5>
+                        <div className="absolute bottom-full left-0 mb-2 w-56 p-2 rounded-sm bg-card/95 backdrop-blur-md border border-border shadow-xl opacity-0 translate-y-2 pointer-events-none group-hover/influences:opacity-100 group-hover/influences:translate-y-0 transition-all z-[100]">
+                          <h5 className="font-mono text-[8px] font-bold text-muted-foreground uppercase tracking-widest mb-1.5 border-b border-border pb-1">Connected nodes</h5>
                           <div className="flex flex-col gap-1">
                             {block.influencedBy.slice(0, 5).map((id, i) => {
                               const linked = allBlocks?.find(b => b.id === id)

--- a/components/tile-index.tsx
+++ b/components/tile-index.tsx
@@ -72,7 +72,7 @@ export function TileIndex({ blocks, onHighlight, highlightedId, onClose, isOpen,
         opacity: isOpen ? 1 : 0,
         visibility: isOpen ? "visible" : "hidden"
       }}
-      className="flex flex-col h-full bg-black/20 backdrop-blur-3xl border-l border-border shrink-0 overflow-hidden relative z-50 transition-all duration-200 ease-in-out"
+      className="flex flex-col h-full bg-secondary/30 backdrop-blur-3xl border-l border-border shrink-0 overflow-hidden relative z-50 transition-all duration-200 ease-in-out"
     >
       <div className="w-[240px] flex flex-col h-full">
         {/* Header */}
@@ -80,7 +80,7 @@ export function TileIndex({ blocks, onHighlight, highlightedId, onClose, isOpen,
           {onClose && (
             <button 
               onClick={onClose}
-              className="p-1 px-1.5 hover:bg-white/5 rounded-sm transition-colors text-muted-foreground/30 hover:text-white"
+              className="p-1 px-1.5 hover:bg-muted/30 rounded-sm transition-colors text-muted-foreground/30 hover:text-foreground"
               title="Close Index"
             >
               <X className="h-3.5 w-3.5" />
@@ -105,7 +105,7 @@ export function TileIndex({ blocks, onHighlight, highlightedId, onClose, isOpen,
                  <button
                     key={col.id}
                     onClick={() => scrollToColumn(col.id)}
-                    className="flex items-center gap-2.5 w-full px-2.5 py-2.5 rounded-sm transition-all hover:bg-white/5 text-left text-foreground/60 hover:text-foreground group"
+                    className="flex items-center gap-2.5 w-full px-2.5 py-2.5 rounded-sm transition-all hover:bg-muted/20 text-left text-foreground/60 hover:text-foreground group"
                  >
                    <col.icon className="h-3 w-3 text-primary/40 group-hover:text-primary transition-colors" />
                    <span className="font-mono text-[11px] font-bold uppercase tracking-tight">{col.label}</span>
@@ -122,7 +122,7 @@ export function TileIndex({ blocks, onHighlight, highlightedId, onClose, isOpen,
                     onMouseEnter={() => onHighlight(block.id)}
                     onMouseLeave={() => onHighlight(null)}
                     onClick={() => scrollToTile(block.id)}
-                    className={`flex items-start gap-2.5 w-full px-2.5 py-2 rounded-sm transition-all hover:bg-white/5 text-left group border-r-2 ${
+                    className={`flex items-start gap-2.5 w-full px-2.5 py-2 rounded-sm transition-all hover:bg-muted/20 text-left group border-r-2 ${
                       highlightedId === block.id 
                         ? "bg-primary/10 border-primary shadow-[inset_0_1px_0px_rgba(255,255,255,0.05)]" 
                         : "border-transparent text-foreground/60 hover:text-foreground"

--- a/components/tiling-area.tsx
+++ b/components/tiling-area.tsx
@@ -242,7 +242,7 @@ export function TilingArea({
   }
 
   return (
-    <div className="relative flex h-full w-full flex-col overflow-hidden bg-[#020202]">
+    <div className="relative flex h-full w-full flex-col overflow-hidden bg-background">
       {/* Task Header stays sticky at top */}
       {taskBlock && (
         <div className={`w-full shrink-0 p-1 z-10 transition-[opacity,filter] duration-300 ${activeConnectionId && !relatedIds.has(taskBlock.id) ? 'opacity-15 saturate-0' : 'opacity-100'}`}>
@@ -291,7 +291,7 @@ export function TilingArea({
                 <div
                   key={idx}
                   data-page-idx={idx}
-                  className={`flex w-full ${heightClass} border-b border-white/5 last:border-0`}
+                  className={`flex w-full ${heightClass} border-b border-border last:border-0`}
                 >
                   {renderBSPNode(tree, chunkedPages[idx])}
                 </div>
@@ -325,7 +325,7 @@ export function TilingArea({
             </div>
 
 
-            <p className="text-[13px] text-white uppercase tracking-[0.15em] whitespace-nowrap">
+            <p className="text-[13px] text-muted-foreground uppercase tracking-[0.15em] whitespace-nowrap">
               {`type anything · #type to classify · ${mod}K for commands`}
             </p>
           </div>

--- a/components/tiling-minimap.tsx
+++ b/components/tiling-minimap.tsx
@@ -19,7 +19,7 @@ export function TilingMinimap({ pages, activePageIdx, onPageClick }: TilingMinim
       initial={{ opacity: 0, x: 8 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.2, ease: "easeOut" }}
-      className="flex flex-col items-center gap-1.5 p-1.5 rounded-lg bg-black/60 backdrop-blur-md border border-white/10 shadow-xl"
+      className="flex flex-col items-center gap-1.5 p-1.5 rounded-lg bg-card/90 backdrop-blur-md border border-border shadow-xl"
     >
       {pages.map((page, idx) => {
         const isActive = idx === activePageIdx
@@ -35,9 +35,9 @@ export function TilingMinimap({ pages, activePageIdx, onPageClick }: TilingMinim
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: 6 }}
                   transition={{ duration: 0.12, ease: "easeOut" }}
-                  className="absolute right-full bottom-0 mr-2.5 w-52 p-2.5 rounded-md bg-black/92 backdrop-blur-md border border-white/10 shadow-2xl pointer-events-none z-50"
+                  className="absolute right-full bottom-0 mr-2.5 w-52 p-2.5 rounded-md bg-card/90 backdrop-blur-md border border-border shadow-2xl pointer-events-none z-50"
                 >
-                  <p className="font-mono text-[7px] uppercase tracking-widest text-white/45 pb-1.5 mb-1.5 border-b border-white/8">
+                  <p className="font-mono text-[7px] uppercase tracking-widest text-muted-foreground pb-1.5 mb-1.5 border-b border-border">
                     Page {idx + 1} · {page.length} tile{page.length !== 1 ? "s" : ""}
                   </p>
                   <div className="flex flex-col gap-1.5">
@@ -52,7 +52,7 @@ export function TilingMinimap({ pages, activePageIdx, onPageClick }: TilingMinim
                             className="h-[5px] w-[5px] rounded-[1px] shrink-0 mt-[3px]"
                             style={{ background: config.accentVar, opacity: 0.85 }}
                           />
-                          <span className="font-mono text-[9px] text-white/65 leading-snug">
+                          <span className="font-mono text-[9px] text-foreground/65 leading-snug">
                             {title}
                           </span>
                         </div>
@@ -71,7 +71,7 @@ export function TilingMinimap({ pages, activePageIdx, onPageClick }: TilingMinim
               className={`group relative flex flex-col items-center gap-[4px] p-1.5 rounded-md transition-all duration-150 outline-none ${
                 isActive
                   ? "bg-primary/15 border border-primary/40 shadow-[0_0_0_1px_var(--primary)]"
-                  : "border border-white/10 bg-white/[0.04] hover:bg-white/[0.09] hover:border-white/25"
+                  : "border border-border bg-muted/20 hover:bg-muted/40 hover:border-border"
               }`}
             >
               {/* Dot grid — up to 3 columns, rows as needed */}
@@ -93,7 +93,7 @@ export function TilingMinimap({ pages, activePageIdx, onPageClick }: TilingMinim
 
               {/* Page number */}
               <span className={`font-mono text-[7px] font-bold leading-none transition-colors ${
-                isActive ? "text-primary/80" : "text-white/35 group-hover:text-white/60"
+                isActive ? "text-primary/80" : "text-muted-foreground group-hover:text-foreground"
               }`}>
                 {idx + 1}
               </span>

--- a/components/vim-input.tsx
+++ b/components/vim-input.tsx
@@ -206,23 +206,23 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 8 }}
               transition={{ duration: 0.15, ease: "easeOut" }}
-              className="absolute bottom-full left-0 right-0 w-full border-t border-white/10 bg-black/85 backdrop-blur-3xl shadow-[0_-24px_60px_-12px_rgba(0,0,0,0.6)]"
+              className="absolute bottom-full left-0 right-0 w-full border-t border-border bg-card/90 backdrop-blur-3xl shadow-[0_-24px_60px_-12px_rgba(0,0,0,0.15)]"
               onKeyDown={handlePopupKeyDown}
             >
               {/* Search input */}
-              <div className="flex items-center gap-3 px-5 py-3 border-b border-white/10">
-                <span className="font-mono text-[9px] uppercase tracking-[0.2em] text-white/60 select-none shrink-0">{mod}K</span>
+              <div className="flex items-center gap-3 px-5 py-3 border-b border-border">
+                <span className="font-mono text-[9px] uppercase tracking-[0.2em] text-muted-foreground select-none shrink-0">{mod}K</span>
                 <input
                   ref={searchInputRef}
                   value={search}
                   onChange={e => setSearch(e.target.value)}
                   placeholder="Search commands…"
-                  className="flex-1 bg-transparent font-mono text-xs text-white/70 placeholder:text-white/55 outline-none"
+                  className="flex-1 bg-transparent font-mono text-xs text-foreground/70 placeholder:text-muted-foreground/50 outline-none"
                 />
                 {search && (
                   <button
                     onClick={() => setSearch("")}
-                    className="text-white/40 hover:text-white/70 transition-colors text-[10px] font-mono"
+                    className="text-muted-foreground hover:text-foreground transition-colors text-[10px] font-mono"
                   >
                     clear
                   </button>
@@ -234,7 +234,7 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
                 {/* ── Views ──────────────────────────────────────────────── */}
                 {viewItems.length > 0 && (
                   <div>
-                    <p className="px-1 pb-2 font-mono text-[8px] font-bold uppercase tracking-[0.2em] text-white/45">Views</p>
+                    <p className="px-1 pb-2 font-mono text-[8px] font-bold uppercase tracking-[0.2em] text-muted-foreground">Views</p>
                     <div className="grid grid-cols-3 gap-1.5">
                       {viewItems.map((item, i) => {
                         const focused = focusedIdx === i
@@ -244,12 +244,12 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
                             ref={el => { itemRefs.current[i] = el }}
                             onClick={() => handleSelect(item.id)}
                             onMouseEnter={() => setFocusedIdx(i)}
-                            className={`group flex flex-col items-center justify-center gap-2 rounded-sm border py-4 px-2 transition-all duration-100 outline-none ${focused ? "bg-primary/12 border-primary/35 text-primary shadow-[0_0_0_1px_var(--primary),inset_0_1px_0_rgba(255,255,255,0.05)]" : "bg-white/[0.03] border-white/[0.07] text-white/55 hover:bg-white/[0.06] hover:border-white/20 hover:text-white/80"}`}
+                            className={`group flex flex-col items-center justify-center gap-2 rounded-sm border py-4 px-2 transition-all duration-100 outline-none ${focused ? "bg-primary/12 border-primary/35 text-primary shadow-[0_0_0_1px_var(--primary),inset_0_1px_0_rgba(255,255,255,0.05)]" : "bg-muted/30 border-border text-muted-foreground hover:bg-muted/50 hover:border-border hover:text-foreground"}`}
                           >
                             <item.icon className={`h-[18px] w-[18px] transition-transform duration-100 ${focused ? "scale-110" : "group-hover:scale-105"}`} />
                             <div className="text-center leading-tight">
                               <div className="font-mono text-[10px] font-bold tracking-tight">{item.label}</div>
-                              {item.sub && <div className={`font-mono text-[7px] uppercase tracking-[0.15em] mt-0.5 ${focused ? "text-primary/60" : "text-white/40"}`}>{item.sub}</div>}
+                              {item.sub && <div className={`font-mono text-[7px] uppercase tracking-[0.15em] mt-0.5 ${focused ? "text-primary/60" : "text-muted-foreground"}`}>{item.sub}</div>}
                             </div>
                           </button>
                         )
@@ -260,8 +260,8 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
 
                 {/* ── Navigate ───────────────────────────────────────────── */}
                 {navItems.length > 0 && (
-                  <div className="border-t border-white/10 pt-3">
-                    <p className="px-1 pb-2 font-mono text-[8px] font-bold uppercase tracking-[0.2em] text-white/45">Navigate</p>
+                  <div className="border-t border-border pt-3">
+                    <p className="px-1 pb-2 font-mono text-[8px] font-bold uppercase tracking-[0.2em] text-muted-foreground">Navigate</p>
                     <div className="grid grid-cols-4 gap-1.5">
                       {navItems.map((item, i) => {
                         const idx     = viewCount + i
@@ -272,12 +272,12 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
                             ref={el => { itemRefs.current[idx] = el }}
                             onClick={() => handleSelect(item.id)}
                             onMouseEnter={() => setFocusedIdx(idx)}
-                            className={`group flex flex-col items-center justify-center gap-2 rounded-sm border py-4 px-2 transition-all duration-100 outline-none ${focused ? "bg-primary/12 border-primary/35 text-primary shadow-[0_0_0_1px_var(--primary),inset_0_1px_0_rgba(255,255,255,0.05)]" : "bg-white/[0.03] border-white/[0.07] text-white/55 hover:bg-white/[0.06] hover:border-white/20 hover:text-white/80"}`}
+                            className={`group flex flex-col items-center justify-center gap-2 rounded-sm border py-4 px-2 transition-all duration-100 outline-none ${focused ? "bg-primary/12 border-primary/35 text-primary shadow-[0_0_0_1px_var(--primary),inset_0_1px_0_rgba(255,255,255,0.05)]" : "bg-muted/30 border-border text-muted-foreground hover:bg-muted/50 hover:border-border hover:text-foreground"}`}
                           >
                             <item.icon className={`h-[18px] w-[18px] transition-transform duration-100 ${focused ? "scale-110" : "group-hover:scale-105"}`} />
                             <div className="text-center leading-tight">
                               <div className="font-mono text-[10px] font-bold tracking-tight">{item.label}</div>
-                              {item.sub && <div className={`font-mono text-[7px] uppercase tracking-[0.15em] mt-0.5 ${focused ? "text-primary/60" : "text-white/40"}`}>{item.sub}</div>}
+                              {item.sub && <div className={`font-mono text-[7px] uppercase tracking-[0.15em] mt-0.5 ${focused ? "text-primary/60" : "text-muted-foreground"}`}>{item.sub}</div>}
                             </div>
                           </button>
                         )
@@ -288,8 +288,8 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
 
                 {/* ── Actions ────────────────────────────────────────────── */}
                 {actionItems.length > 0 && (
-                  <div className="border-t border-white/10 pt-3">
-                    <p className="px-1 pb-2 font-mono text-[8px] font-bold uppercase tracking-[0.2em] text-white/45">Actions</p>
+                  <div className="border-t border-border pt-3">
+                    <p className="px-1 pb-2 font-mono text-[8px] font-bold uppercase tracking-[0.2em] text-muted-foreground">Actions</p>
                     <div className="grid grid-cols-5 gap-1.5">
                       {actionItems.map((item, i) => {
                         const idx     = viewCount + navCount + i
@@ -300,12 +300,12 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
                             ref={el => { itemRefs.current[idx] = el }}
                             onClick={() => handleSelect(item.id)}
                             onMouseEnter={() => setFocusedIdx(idx)}
-                            className={`group flex flex-col items-center justify-center gap-2 rounded-sm border py-4 px-2 transition-all duration-100 outline-none ${focused ? "bg-primary/12 border-primary/35 text-primary shadow-[0_0_0_1px_var(--primary),inset_0_1px_0_rgba(255,255,255,0.05)]" : "bg-white/[0.03] border-white/[0.07] text-white/55 hover:bg-white/[0.06] hover:border-white/20 hover:text-white/80"}`}
+                            className={`group flex flex-col items-center justify-center gap-2 rounded-sm border py-4 px-2 transition-all duration-100 outline-none ${focused ? "bg-primary/12 border-primary/35 text-primary shadow-[0_0_0_1px_var(--primary),inset_0_1px_0_rgba(255,255,255,0.05)]" : "bg-muted/30 border-border text-muted-foreground hover:bg-muted/50 hover:border-border hover:text-foreground"}`}
                           >
                             <item.icon className={`h-[18px] w-[18px] transition-transform duration-100 ${focused ? "scale-110" : "group-hover:scale-105"}`} />
                             <div className="text-center leading-tight">
                               <div className="font-mono text-[10px] font-bold tracking-tight">{item.label}</div>
-                              <div className={`font-mono text-[7px] uppercase tracking-[0.15em] mt-0.5 ${focused ? "text-primary/60" : "text-white/40"}`}>{item.sub}</div>
+                              {item.sub && <div className={`font-mono text-[7px] uppercase tracking-[0.15em] mt-0.5 ${focused ? "text-primary/60" : "text-muted-foreground"}`}>{item.sub}</div>}
                             </div>
                           </button>
                         )
@@ -316,14 +316,14 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
 
                 {/* ── Empty state ────────────────────────────────────────── */}
                 {totalItems === 0 && (
-                  <div className="py-10 text-center font-mono text-[9px] uppercase tracking-[0.2em] text-white/45">
+                  <div className="py-10 text-center font-mono text-[9px] uppercase tracking-[0.2em] text-muted-foreground">
                     No commands match
                   </div>
                 )}
               </div>
 
               {/* Footer hint */}
-              <div className="flex items-center justify-end gap-4 px-5 py-2 border-t border-white/10">
+              <div className="flex items-center justify-end gap-4 px-5 py-2 border-t border-border">
                 {[
                   ["↑↓", "rows"],
                   ["←→", "tiles"],
@@ -331,8 +331,8 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
                   ["esc","close"],
                 ].map(([key, label]) => (
                   <div key={key} className="flex items-center gap-1.5">
-                    <kbd className="font-mono text-[9px] text-white/50 bg-white/8 border border-white/15 rounded px-1 py-0.5">{key}</kbd>
-                    <span className="font-mono text-[8px] uppercase tracking-wider text-white/60">{label}</span>
+                    <kbd className="font-mono text-[9px] text-muted-foreground bg-muted/30 border border-border rounded px-1 py-0.5">{key}</kbd>
+                    <span className="font-mono text-[8px] uppercase tracking-wider text-muted-foreground">{label}</span>
                   </div>
                 ))}
               </div>
@@ -341,11 +341,11 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
         </AnimatePresence>
 
         {/* ── Main Input Bar ─────────────────────────────────────────────── */}
-        <div className="w-full border-t border-white/20 bg-black/80 backdrop-blur-3xl px-6 py-5 flex items-center gap-4 transition-all duration-300 focus-within:border-primary/40 relative">
+        <div className="w-full border-t border-border bg-card/80 backdrop-blur-3xl px-6 py-5 flex items-center gap-4 transition-all duration-300 focus-within:border-primary/40 relative">
           <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-primary/20 to-transparent" />
 
           <div className="flex items-center gap-3 flex-1">
-            <div className="font-mono text-[10px] font-bold text-white/60 uppercase tracking-[0.2em] select-none">
+            <div className="font-mono text-[10px] font-bold text-muted-foreground uppercase tracking-[0.2em] select-none">
               Entry
             </div>
             <Command.Input
@@ -353,31 +353,31 @@ export function VimInput({ onSubmit, onCommand, isCommandKOpen, setIsCommandKOpe
               value={value}
               onValueChange={setValue}
               placeholder="Capture something..."
-              className="flex-1 bg-transparent font-mono text-sm tracking-tight text-white outline-none placeholder:text-white/55"
+              className="flex-1 bg-transparent font-mono text-sm tracking-tight text-foreground placeholder:text-muted-foreground/70 outline-none"
               autoFocus
             />
           </div>
 
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2">
-              <kbd className="flex h-5 items-center rounded border border-white/10 bg-white/5 px-1.5 font-mono text-[9px] text-white/60">
+              <kbd className="flex h-5 items-center rounded border border-border bg-muted/30 px-1.5 font-mono text-[9px] text-muted-foreground">
                 <span className="text-[11px] mr-1">⌘</span>
                 <span>Z</span>
               </kbd>
-              <span className="text-[9px] font-mono font-bold text-white/55 uppercase tracking-tighter">Undo</span>
+              <span className="text-[9px] font-mono font-bold text-muted-foreground uppercase tracking-tighter">Undo</span>
             </div>
 
-            <div className="h-4 w-px bg-white/10" />
+            <div className="h-4 w-px bg-border" />
 
             <div className="flex items-center gap-2">
-              <kbd className="flex h-5 items-center rounded border border-white/10 bg-white/5 px-1.5 font-mono text-[9px] text-white/60">
+              <kbd className="flex h-5 items-center rounded border border-border bg-muted/30 px-1.5 font-mono text-[9px] text-muted-foreground">
                 <span className="text-[11px] mr-1">⌘</span>
                 <span>K</span>
               </kbd>
-              <span className="text-[9px] font-mono font-bold text-white/55 uppercase tracking-tighter">Commands</span>
+              <span className="text-[9px] font-mono font-bold text-muted-foreground uppercase tracking-tighter">Commands</span>
             </div>
 
-            <div className="h-4 w-px bg-white/20" />
+            <div className="h-4 w-px bg-border" />
 
             <button
               onClick={() => {

--- a/lib/ai-settings.ts
+++ b/lib/ai-settings.ts
@@ -12,7 +12,7 @@ export interface AIModel {
   groundingModelId?: string
 }
 
-export type AIProvider = "openrouter" | "openai" | "zai"
+export type AIProvider = "openrouter" | "openai" | "zai" | "anthropic"
 
 export interface AIProviderPreset {
   id: AIProvider
@@ -43,6 +43,13 @@ export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
     baseUrl: "https://api.z.ai/api/paas/v4",
     keyUrl: "https://z.ai/manage-apikey/apikey-list",
     keyPlaceholder: "Your Z.ai API key",
+  },
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    baseUrl: "https://api.anthropic.com/v1",
+    keyUrl: "https://console.anthropic.com/settings/keys",
+    keyPlaceholder: "sk-ant-api03-...",
   },
 ]
 
@@ -174,9 +181,76 @@ export const ZAI_MODELS: AIModel[] = [
   },
 ]
 
+export const ANTHROPIC_MODELS: AIModel[] = [
+  {
+    id: "claude-fable-5",
+    label: "Claude Fable 5",
+    shortLabel: "Fable 5",
+    description: "Next-gen intelligence for long-running agents",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-opus-4-8",
+    label: "Claude Opus 4.8",
+    shortLabel: "Opus 4.8",
+    description: "Complex agentic coding & enterprise work",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-sonnet-5",
+    label: "Claude Sonnet 5",
+    shortLabel: "Sonnet 5",
+    description: "Best balance of speed and intelligence",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-haiku-4-5",
+    label: "Claude Haiku 4.5",
+    shortLabel: "Haiku 4.5",
+    description: "Fastest model, near-frontier intelligence",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-opus-4-7",
+    label: "Claude Opus 4.7",
+    shortLabel: "Opus 4.7",
+    description: "Previous-gen Opus — adaptive thinking",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-opus-4-6",
+    label: "Claude Opus 4.6",
+    shortLabel: "Opus 4.6",
+    description: "Extended thinking, 1M context",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-sonnet-4-6",
+    label: "Claude Sonnet 4.6",
+    shortLabel: "Sonnet 4.6",
+    description: "Extended thinking, 1M context",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-sonnet-4-5",
+    label: "Claude Sonnet 4.5",
+    shortLabel: "Sonnet 4.5",
+    description: "Extended thinking, 200K context",
+    supportsGrounding: false,
+  },
+  {
+    id: "claude-opus-4-5",
+    label: "Claude Opus 4.5",
+    shortLabel: "Opus 4.5",
+    description: "Extended thinking, 200K context",
+    supportsGrounding: false,
+  },
+]
+
 export function getModelsForProvider(provider: AIProvider): AIModel[] {
   if (provider === "openai") return OPENAI_MODELS
   if (provider === "zai")    return ZAI_MODELS
+  if (provider === "anthropic") return ANTHROPIC_MODELS
   return AI_MODELS // openrouter + safe fallback for any stale localStorage value
 }
 
@@ -206,6 +280,10 @@ export async function fetchModelsFromProvider(
   if (provider === "openrouter") {
     headers["HTTP-Referer"] = "https://nodepad.space"
     headers["X-Title"] = "nodepad"
+  }
+  if (provider === "anthropic") {
+    headers["x-api-key"] = apiKey
+    headers["anthropic-version"] = "2023-06-01"
   }
   const res = await fetch(`${baseUrl}/models`, { headers })
   if (!res.ok) throw new Error(`Failed to fetch models (${res.status})`)
@@ -298,6 +376,10 @@ export function getProviderHeaders(config: AIConfig): Record<string, string> {
   if (config.provider === "openrouter") {
     base["HTTP-Referer"] = "https://nodepad.space"
     base["X-Title"] = "nodepad"
+  }
+  if (config.provider === "anthropic") {
+    base["x-api-key"] = config.apiKey
+    base["anthropic-version"] = "2023-06-01"
   }
   return base
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -762,9 +762,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1447,15 +1447,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.2.tgz",
-      "integrity": "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.2.tgz",
-      "integrity": "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
-      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1485,11 +1485,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
-      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1501,11 +1504,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
-      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1517,11 +1523,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
-      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1533,11 +1542,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
-      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1549,9 +1561,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
-      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -1565,9 +1577,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz",
-      "integrity": "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -4251,9 +4263,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5781,13 +5793,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5839,9 +5851,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -6298,9 +6310,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.22",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6439,9 +6451,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8268,9 +8280,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -8296,12 +8308,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
-      "integrity": "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.2",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -8315,14 +8327,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.2",
-        "@next/swc-darwin-x64": "16.2.2",
-        "@next/swc-linux-arm64-gnu": "16.2.2",
-        "@next/swc-linux-arm64-musl": "16.2.2",
-        "@next/swc-linux-x64-gnu": "16.2.2",
-        "@next/swc-linux-x64-musl": "16.2.2",
-        "@next/swc-win32-arm64-msvc": "16.2.2",
-        "@next/swc-win32-x64-msvc": "16.2.2",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -8726,9 +8738,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -8745,7 +8757,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8868,9 +8880,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Adds Anthropic as a native provider alongside OpenRouter, OpenAI, and Z.ai
- Full model lineup: Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5, plus legacy models (Opus 4.5–4.7, Sonnet 4.5–4.6)
- Uses Anthropic's OpenAI-compatible endpoint (`api.anthropic.com/v1`) with `x-api-key` + `anthropic-version` headers
- Provider selectable in Settings sidebar, models searchable in the dropdown
- Dynamic model fetching works via Anthropic's `/v1/models` endpoint

## Changes
| File | Changes |
|------|---------|
| `lib/ai-settings.ts` | Provider preset, 9-model lineup, auth headers, provider routing |
| `components/about-panel.tsx` | Updated provider list text |